### PR TITLE
feat: Add Bank Transaction to Assign Payment Entry

### DIFF
--- a/erpnextfints/erpnextfints/doctype/payment_wizard_setting/payment_wizard_setting.js
+++ b/erpnextfints/erpnextfints/doctype/payment_wizard_setting/payment_wizard_setting.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2024, jHetzer and contributors
+// For license information, please see license.txt
+
+// frappe.ui.form.on("Payment Wizard Setting", {
+// 	refresh(frm) {
+
+// 	},
+// });

--- a/erpnextfints/erpnextfints/doctype/payment_wizard_setting/payment_wizard_setting.json
+++ b/erpnextfints/erpnextfints/doctype/payment_wizard_setting/payment_wizard_setting.json
@@ -1,0 +1,41 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2024-03-15 12:45:58.428614",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "show_entries_in_payment_assignment_wizard"
+ ],
+ "fields": [
+  {
+   "fieldname": "show_entries_in_payment_assignment_wizard",
+   "fieldtype": "Select",
+   "label": "Show Entries in Payment Assignment Wizard",
+   "options": "Payment Entry\nBank Transaction\nBoth"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "issingle": 1,
+ "links": [],
+ "modified": "2024-03-15 12:49:39.431666",
+ "modified_by": "Administrator",
+ "module": "Erpnextfints",
+ "name": "Payment Wizard Setting",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "print": 1,
+   "read": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/erpnextfints/erpnextfints/doctype/payment_wizard_setting/payment_wizard_setting.py
+++ b/erpnextfints/erpnextfints/doctype/payment_wizard_setting/payment_wizard_setting.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2024, jHetzer and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class PaymentWizardSetting(Document):
+	pass

--- a/erpnextfints/erpnextfints/doctype/payment_wizard_setting/test_payment_wizard_setting.py
+++ b/erpnextfints/erpnextfints/doctype/payment_wizard_setting/test_payment_wizard_setting.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2024, jHetzer and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestPaymentWizardSetting(FrappeTestCase):
+	pass

--- a/erpnextfints/erpnextfints/page/assign_payment_entries/assign_payment_entries.js
+++ b/erpnextfints/erpnextfints/page/assign_payment_entries/assign_payment_entries.js
@@ -2,10 +2,10 @@
 // For license information, please see license.txt
 frappe.provide("erpnextfints.tools");
 
-
-frappe.pages['assign_payment_entries'].on_page_load = function(wrapper) {
+frappe.pages["assign_payment_entries"].on_page_load = function (wrapper) {
 	erpnextfints.tools.assignWizardObj = new erpnextfints.tools.assignWizard(
-		wrapper);
+		wrapper
+	);
 };
 
 erpnextfints.tools.assignWizard = class assignWizard {
@@ -13,7 +13,7 @@ erpnextfints.tools.assignWizard = class assignWizard {
 		this.page = frappe.ui.make_app_page({
 			parent: wrapper,
 			title: __("Assign Payment Wizard"),
-			single_column: true
+			single_column: true,
 		});
 		this.parent = wrapper;
 		this.page = this.parent.page;
@@ -32,72 +32,97 @@ erpnextfints.tools.assignWizard = class assignWizard {
 		const me = this;
 
 		me.page.show_menu();
-		me.page.add_menu_item(__("Auto assign"), function() {
-			frappe.call({
-				method: "erpnextfints.utils.client.auto_assign_payments",
-				args: {},
-				callback: function(r) {
-					if(r.message.success === true ){
-						var result = [];
-						if(Array.isArray(r.message.payments) && r.message.payments.length ){
-							result.push(__("Assingment was successfull"));
-							r.message.payments.forEach(function(item) {
-								result.push(
-									__("Payment") + " " +
-									get_doc_link("Payment Entry",item.PaymentName) +
-									" " + __("from customer") + " " +
-									get_doc_link("Customer",item.CustomerName) + " " +
-									__("has been assinged to sale invoice") + " " +
-									get_doc_link("Sales Invoice",item.SaleName)
-								);
-							});
-						}else{
-							result.push(__("No payments were found for assignment"));
+		me.page.add_menu_item(
+			__("Auto assign"),
+			function () {
+				frappe.call({
+					method: "erpnextfints.utils.client.auto_assign_payments",
+					args: {},
+					callback: function (r) {
+						if (r.message.success === true) {
+							var result = [];
+							if (
+								Array.isArray(r.message.payments) &&
+								r.message.payments.length
+							) {
+								result.push(__("Assingment was successfull"));
+								r.message.payments.forEach(function (item) {
+									result.push(
+										__("Payment") +
+											" " +
+											get_doc_link("Payment Entry", item.PaymentName) +
+											" " +
+											__("from customer") +
+											" " +
+											get_doc_link("Customer", item.CustomerName) +
+											" " +
+											__("has been assinged to sale invoice") +
+											" " +
+											get_doc_link("Sales Invoice", item.SaleName)
+									);
+								});
+							} else {
+								result.push(__("No payments were found for assignment"));
+							}
+							erpnextfints.tools.assignWizardList.refresh();
+							frappe.msgprint(result);
+						} else {
+							frappe.msgprint(__("Failed to assign payments"));
 						}
-						erpnextfints.tools.assignWizardList.refresh();
-						frappe.msgprint(result);
-					} else {
-						frappe.msgprint(__("Failed to assign payments"));
-					}
-				}
-			});
-		}, true);
+					},
+				});
+			},
+			true
+		);
 	}
 
 	clear_page_content() {
 		const me = this;
 		me.page.clear_fields();
-		$(me.page.body).find('.frappe-list').remove();
+		$(me.page.body).find(".frappe-list").remove();
 	}
 
 	make_assignWizard_tool() {
 		const me = this;
+		// ensure that the metadata for the "Sales Invoice" DocType is loaded before proceeding with the wizard setup(AssignWizardTool).
+
 		frappe.model.with_doctype("Sales Invoice", () => {
-			erpnextfints.tools.assignWizardList = new erpnextfints.tools.AssignWizardTool({
-				parent: me.parent,
-				doctype: "Sales Invoice",
-				page_title: __(me.page.title),
-			});
-			frappe.pages['assign_payment_entries'].refresh = function(/* wrapper */) {
-				window.location.reload(false);
-			};
+			erpnextfints.tools.assignWizardList =
+				new erpnextfints.tools.AssignWizardTool({
+					parent: me.parent,
+					doctype: "Sales Invoice",
+					page_title: __(me.page.title),
+				});
+			frappe.pages["assign_payment_entries"].refresh =
+				function (/* wrapper */) {
+					window.location.reload(false);
+				};
 		});
 	}
 };
 
-
-erpnextfints.tools.AssignWizardTool = class AssignWizardTool extends frappe.views.BaseList {
+erpnextfints.tools.AssignWizardTool = class AssignWizardTool extends (
+	frappe.views.BaseList
+) {
 	constructor(opts) {
 		super(opts);
 		this.show();
 	}
 
+	// It establishes default settings for various aspects of the assignment wizard tool's data display and behavior
 	setup_defaults() {
 		super.setup_defaults();
 		this.page_length = 100;
-		this.sort_by = 'customer';
-		this.sort_order = 'asc';
-		this.fields = ['name', 'customer', 'outstanding_amount','posting_date', 'due_date', 'currency'];
+		this.sort_by = "customer";
+		this.sort_order = "asc";
+		this.fields = [
+			"name",
+			"customer",
+			"outstanding_amount",
+			"posting_date",
+			"due_date",
+			"currency",
+		];
 	}
 
 	setup_view() {
@@ -124,57 +149,115 @@ erpnextfints.tools.AssignWizardTool = class AssignWizardTool extends frappe.view
 		const args = super.get_args();
 
 		return Object.assign({}, args, {
-			...args.filters.push(["Sales Invoice", "docstatus", "=", 1],
-				["Sales Invoice", "outstanding_amount", ">", 0])
+			...args.filters.push(
+				["Sales Invoice", "docstatus", "=", 1],
+				["Sales Invoice", "outstanding_amount", ">", 0]
+			),
 		});
 	}
 
-	get_row_call_args(customer) {
+	get_row_call_args(customer, optionValue) {
+		let doctype, fields, filters, order_by;
+
+		if (optionValue == "Payment Entry") {
+			doctype = "Payment Entry";
+			fields = [
+				"name",
+				"party",
+				"posting_date",
+				"unallocated_amount",
+				"remarks",
+			];
+			filters = {
+				docstatus: 0,
+				party: customer,
+			};
+			order_by = "posting_date";
+		} else if (optionValue == "Bank Transaction") {
+			doctype = "Bank Transaction";
+			fields = ["name", "party", "date", "unallocated_amount", "description"];
+			filters = {
+				docstatus: 1,
+				party: customer,
+			};
+			order_by = "date";
+		} else {
+			// code if both are selected
+		}
 		return {
 			method: "frappe.client.get_list",
 			args: {
-				doctype: "Payment Entry",
-				fields: ["name","party","posting_date", "unallocated_amount","remarks"],
-				filters: {
-					"docstatus":0,
-					"party":customer,
-				},
-				order_by: 'posting_date',
+				doctype,
+				fields,
+				filters,
+				order_by,
 			},
 			freeze: this.freeze_on_refresh || false,
-			freeze_message: this.freeze_message || (__('Loading') + '...')
+			freeze_message: this.freeze_message || __("Loading") + "...",
 		};
 	}
 
-	render() {
+	async render() {
+		const selectedOption = await frappe.call({
+			method: "frappe.client.get_value",
+			args: {
+				doctype: "Payment Wizard Setting",
+				filters: {},
+				fieldname: "show_entries_in_payment_assignment_wizard",
+			},
+		});
+
+		// Extract the selected value from "Payment Wizard Setting" doctype
+		const optionValue =
+			selectedOption.message.show_entries_in_payment_assignment_wizard;
+		console.log("option", optionValue);
+
 		const me = this;
-		this.$result.find('.list-row-container').remove();
+		this.$result.find(".list-row-container").remove();
 		$('[data-fieldname="name"]').remove();
 		$('[data-fieldname="status"]').remove();
 		$('[data-fieldname="title"]').remove();
+		let index = 0;
+		let rowHTML;
+		// me.data - list of sales invoice. the below code fetchs all payment entries associated with single sales invoice
+		for (const value of me.data) {
+			rowHTML =
+				index % 2 !== 0
+					? '<div class="list-row-container" style="background-color: #F3F3F3">'
+					: '<div class="list-row-container">';
 
-		me.data.map((value) => {
-			frappe.call(this.get_row_call_args(value.customer)).then(r => {
-				if(Array.isArray(r.message) && r.message.length){
-					const row = $('<div class="list-row-container">').data("data", value).appendTo(me.$result).get(0);
-					new erpnextfints.tools.AssignWizardRow(row, value, r.message);
-				}
-			});
-		});
+			const r = await frappe.call(
+				this.get_row_call_args(value.customer, optionValue)
+			);
+
+			//r.message - list of all payment entries
+			if (Array.isArray(r.message) && r.message.length) {
+				const row = $(rowHTML).data("data", value).appendTo(me.$result).get(0);
+
+				new erpnextfints.tools.AssignWizardRow(
+					row,
+					value,
+					r.message,
+					optionValue
+				);
+			}
+			index += 1;
+		}
 	}
 
 	render_header() {
 		const me = this;
-		if ($(this.wrapper).find('.payment-assign-wizard-header').length === 0) {
+		if ($(this.wrapper).find(".payment-assign-wizard-header").length === 0) {
 			me.$result.append(frappe.render_template("sale_invoice_header"));
 		}
 	}
 };
 
 erpnextfints.tools.AssignWizardRow = class AssignWizardRow {
-	constructor(row, data, payments) {
+	constructor(row, data, payments, optionValue) {
 		this.data = data;
 		this.data.payments = payments;
+		this.data.optionValue = optionValue;
 		this.row = row;
 		this.make();
 		this.bind_events();
@@ -187,27 +270,47 @@ erpnextfints.tools.AssignWizardRow = class AssignWizardRow {
 	bind_events() {
 		const me = this;
 
-		$(me.row).on('click', '.hide_row', function() {
+		$(me.row).on("click", ".hide_row", function () {
 			me.row.remove();
 		});
-		$(me.row).on('click', '.assign_payment', function() {
+		// assign payment entries to sales invoice
+		$(me.row).on("click", ".assign_payment", function () {
 			frappe.call({
 				method: "erpnextfints.utils.client.add_payment_reference",
 				args: {
-					"sales_invoice": me.data.name,
-					"payment_entry": $(this).attr("data-name"),
+					sales_invoice: me.data.name,
+					payment_entry: $(this).attr("data-name"),
 				},
 				callback(/* r */) {
 					// Refresh page after asignment
 					erpnextfints.tools.assignWizardList.refresh();
-				}
+				},
 			});
+		});
+
+		// reconcile bank transaction against sales invoice
+		$(me.row).on("click", ".reconcile_transaction", function () {
+			console.log(
+				"sales invoice",
+				me.data.name,
+				"bank_transaction",
+				$(this).attr("data-name")
+			);
+			// frappe.call({
+			// 	method: "erpnextfints.utils.client.add_payment_reference",
+			// 	args: {
+			// 		sales_invoice: me.data.name,
+			// 		payment_entry: $(this).attr("data-name"),
+			// 	},
+			// 	callback(/* r */) {
+			// 		// Refresh page after asignment
+			// 		erpnextfints.tools.assignWizardList.refresh();
+			// 	},
+			// });
 		});
 	}
 };
 
-function get_doc_link(doctype, name){
-	return '<a href="#Form/' + doctype + '/' +
-		name+'"><b>' +
-		name + `</b></a>`;
+function get_doc_link(doctype, name) {
+	return '<a href="#Form/' + doctype + "/" + name + '"><b>' + name + `</b></a>`;
 }

--- a/erpnextfints/erpnextfints/page/assign_payment_entries/sale_invoice_header.html
+++ b/erpnextfints/erpnextfints/page/assign_payment_entries/sale_invoice_header.html
@@ -16,8 +16,9 @@
     <div class="col-sm-2 ellipsis list-subject hidden-xs">
       {{ __("Due Date") }}
     </div>
+
     <!-- <div class="col-sm-1 ellipsis level-right">
-			  <span class="list-count"><span>20 of 72</span></span>
-		  </div> -->
+			<span class="list-count"><span>20 of 72</span></span>
+		</div> -->
   </div>
 </div>

--- a/erpnextfints/erpnextfints/page/assign_payment_entries/sale_invoice_row.html
+++ b/erpnextfints/erpnextfints/page/assign_payment_entries/sale_invoice_row.html
@@ -27,7 +27,7 @@
 </div>
 
 <!-- Payment Entries -->
-{% for payment in payments %}
+{% if optionValue == "Payment Entry" %} {% for payment in payments %}
 <div class="list-row payment-assign-wizard-item" style="height: auto">
   <div class="row">
     <div class="col-sm-2 ellipsis">
@@ -52,4 +52,32 @@
     </div>
   </div>
 </div>
-{% endfor %}
+{% endfor %} {% endif %}
+
+<!-- Bank Transactions -->
+{% if optionValue == "Bank Transaction" %} {% for payment in payments %}
+<div class="list-row payment-assign-wizard-item" style="height: auto">
+  <div class="row">
+    <div class="col-sm-2 ellipsis">
+      <a href="bank-transaction/{{ payment.name }}">{{ payment.name }}</a>
+    </div>
+    <div class="col-sm-2 ellipsis hidden-xs">{{ payment.party }}</div>
+    <div class="col-sm-2 ellipsis">
+      {{ payment.unallocated_amount }} {{ currency }}
+    </div>
+    <div class="col-sm-2 ellipsis">{{ payment.date }}</div>
+    <div class="col-sm-3 ellipsis hidden-xs" style="white-space: normal">
+      {{ payment.description}}
+    </div>
+    <div class="col-sm-1" style="padding-right: 0px">
+      <button
+        class="reconcile_transaction btn btn-default btn-xs center-block"
+        data-name="{{ payment.name }}"
+        style="padding-top: 0px; padding-bottom: 0px"
+      >
+        {{ __("Reconcile") }}
+      </button>
+    </div>
+  </div>
+</div>
+{% endfor %} {% endif %}


### PR DESCRIPTION
Added Bank Transactions that match with sales invoice in additon to Payment Entries on Assign Payment Wizard.

Before
![image (3)](https://github.com/phamos-eu/kefiya/assets/71070205/a6f05a5e-ceca-4588-b32c-213186f75d3d)

After
![Screenshot from 2024-03-15 11-20-42](https://github.com/phamos-eu/kefiya/assets/71070205/160a9252-7d08-4d63-98b8-246623667059)
![image (2)](https://github.com/phamos-eu/kefiya/assets/71070205/1c1eb6a9-47b7-41a6-85cd-78a753212046)
