### PR TITLE
feat: group by IBAN

### DIFF
--- a/erpnextfints/erpnextfints/page/bank_account_wizard/bank_account_wizard.js
+++ b/erpnextfints/erpnextfints/page/bank_account_wizard/bank_account_wizard.js
@@ -24,15 +24,15 @@ erpnextfints.tools.bankWizard = class BankWizard {
 	make() {
 		const me = this;
 
-		me.$main_section = $(
-			`<div class="reconciliation page-main-content"></div>`).appendTo(me
-			.page.main);
-		const empty_state = __(
-			"Upload a bank statement, link or reconcile a bank account");
-		me.$main_section.append(
-			`<div class="flex justify-center align-center text-muted"
-			style="height: 50vh; display: flex;"><h5 class="text-muted">${empty_state}</h5></div>`
-		);
+		// me.$main_section = $(
+		// 	`<div class="reconciliation page-main-content"></div>`).appendTo(me
+		// 	.page.main);
+		// const empty_state = __(
+		// 	"Upload a bank statement, link or reconcile a bank account");
+		// me.$main_section.append(
+		// 	`<div class="flex justify-center align-center text-muted"
+		// 	style="height: 50vh; display: flex;"><h5 class="text-muted">${empty_state}</h5></div>`
+		// );
 		me.clear_page_content();
 		me.make_bankwizard_tool();
 		me.add_actions();
@@ -72,7 +72,7 @@ erpnextfints.tools.bankWizard = class BankWizard {
 		const me = this;
 		me.page.clear_fields();
 		$(me.page.body).find('.frappe-list').remove();
-		me.$main_section.empty();
+		// me.$main_section.empty();
 	}
 
 	make_bankwizard_tool() {
@@ -88,7 +88,9 @@ erpnextfints.tools.bankWizard = class BankWizard {
 						page_title: __(me.page.title),
 						ref_items: r.message
 					});
-					frappe.pages['bank_account_wizard'].refresh = function(/* wrapper */) {
+					frappe.pages['bank_account_wizard'].refresh = 
+					function(/* wrapper */) {
+						console.log('here')
 						window.location.reload(false);
 					};
 				});

--- a/erpnextfints/erpnextfints/page/bank_account_wizard/bank_account_wizard_row.html
+++ b/erpnextfints/erpnextfints/page/bank_account_wizard/bank_account_wizard_row.html
@@ -28,7 +28,7 @@
 		</div> -->
 		<div class="col-sm-3 hidden-xs">
 			<div class="clickable-section" data-name={{ name }}>
-				<a href="#Form/Payment Entry/{{ name }}">{{ bank_party_iban }}</a>
+				<div class="ellipsis">{{ bank_party_iban }}</div>
 			</div>
 		</div>
 		<div class="col-sm-1">

--- a/erpnextfints/public/js/controllers/iban_tools.js
+++ b/erpnextfints/public/js/controllers/iban_tools.js
@@ -111,6 +111,8 @@ erpnextfints.iban_tools = {
 						)) {
 							frappe.msgprint(__("Default party selected, please change party"));
 						} else {
+							
+							let defalutValue = frm.doc.party_type ? frm.doc.party_type:frm.doc.deposit > 0 ? 'Customer': 'Supplier'
 							let dialog = new frappe.ui.Dialog({
 								title: __('Create Bank Account'),
 								fields: [{
@@ -142,13 +144,17 @@ erpnextfints.iban_tools = {
 									fieldname: 'party_type',
 									fieldtype: 'Link',
 									options: "Party Type",
-									default: frm.doc.party_type,
+									default: defalutValue,
+									onchange: function(){
+										dialog.fields_dict['party'].df.options = dialog.get_value('party_type');
+										dialog.fields_dict['party'].refresh();
+									}
 								}, {
 									label: 'Party',
 									fieldname: 'party',
 									fieldtype: 'Link',
-									options: "Customer",
 									default: frm.doc.party,
+									options: defalutValue
 								}, {
 									label: 'GL Account',
 									fieldname: 'gl_account',

--- a/erpnextfints/utils/sql/bank_wizard.sql
+++ b/erpnextfints/utils/sql/bank_wizard.sql
@@ -15,3 +15,6 @@ WHERE
 
   AND tBT.docstatus != 2
   AND tBT.bank_party_iban IS NOT NULL
+  GROUP BY
+  -- Remove duplicate entires
+  tBT.bank_party_iban


### PR DESCRIPTION
Fix on the Bank Account Wizard
1, removed clickable link on the IBAN
2, refresh the page after creating a bank account
3, add clickable link to a successful message which routes to created bank account
4, fix dynamic link on the dialog or pop-up
5, set customer/supplier automatically on the pop-up based on the deposit and withdrawal value
6, check swift number or bank name already exists on the Bank doctype before creating a new one
7, group by IBAN or shows one entry per IBAN on the Bank Account Wizard page and when submit button clicked, it will set the party and party_type values to all the bank transactions which have the same IBAN