### PR TITLE
feat: bank transaction cleanup

### DIFF
--- a/erpnextfints/erpnextfints/doctype/kefiya_settings/kefiya_settings.json
+++ b/erpnextfints/erpnextfints/doctype/kefiya_settings/kefiya_settings.json
@@ -14,7 +14,7 @@
    "fieldname": "show_entries_in_payment_assignment_wizard",
    "fieldtype": "Select",
    "label": "Show Entries in Payment Assignment Wizard",
-   "options": "Payment Entry\nBank Transaction\nBoth"
+   "options": "Payment Entry\nBank Transaction"
   },
   {
    "fieldname": "mode_of_payment",
@@ -26,7 +26,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2024-04-05 15:40:32.760747",
+ "modified": "2024-05-28 15:27:44.408798",
  "modified_by": "Administrator",
  "module": "ERPNextFinTS",
  "name": "Kefiya Settings",

--- a/erpnextfints/erpnextfints/page/assign_payment_entries/assign_payment_entries.json
+++ b/erpnextfints/erpnextfints/page/assign_payment_entries/assign_payment_entries.json
@@ -1,9 +1,11 @@
 {
  "content": null,
+ "creation": "2024-05-23 14:53:17.452379",
  "docstatus": 0,
  "doctype": "Page",
  "icon": "",
  "idx": 0,
+ "modified": "2024-05-28 14:55:03.912068",
  "modified_by": "Administrator",
  "module": "ERPNextFinTS",
  "name": "assign_payment_entries",

--- a/erpnextfints/erpnextfints/page/bank_transaction_wiz/bank_transaction_header.html
+++ b/erpnextfints/erpnextfints/page/bank_transaction_wiz/bank_transaction_header.html
@@ -7,19 +7,15 @@
 </style>
 <div class="payment-assign-wizard-header">
   <div class="level list-row list-row-head text-muted small">
-    <div class="col-sm-1 ellipsis">{{ __("Action") }}</div>
+    <div class="col-sm-2 ellipsis">{{ __("Action") }}</div>
     <div class="col-sm-2 ellipsis">{{ __("Name") }}</div>
     <div class="col-sm-2 ellipsis hidden-xs">{{ __("Customer") }}</div>
     <div class="col-sm-2 ellipsis hidden-xs">
       {{ __("Outstanding Amount") }}
     </div>
-    <div class="col-sm-2 ellipsis hidden-xs">{{ __("Posting Date") }}</div>
+    <!-- <div class="col-sm-2 ellipsis hidden-xs">{{ __("Posting Date") }}</div> -->
     <div class="col-sm-2 ellipsis list-subject hidden-xs">
-      {{ __("Due Date") }}
+      {{ __("Posting Date") }}
     </div>
-
-    <!-- <div class="col-sm-1 ellipsis level-right">
-			<span class="list-count"><span>20 of 72</span></span>
-		</div> -->
   </div>
 </div>

--- a/erpnextfints/erpnextfints/page/bank_transaction_wiz/bank_transaction_row.html
+++ b/erpnextfints/erpnextfints/page/bank_transaction_wiz/bank_transaction_row.html
@@ -3,13 +3,13 @@
   <div>
     <div class="clickable-section" data-name="{{ name }}">
       <div class="row">
-        <div class="col-sm-1 hidden-xs" style="padding-right: 0px">
+        <div class="col-sm-2 hidden-xs" style="padding-right: 0px">
           <button
             class="hide_row btn btn-default btn-xs hidden-xs center-block"
             data-name="{{ name }}"
-            style="padding-top: 0px; padding-bottom: 0px; margin-left: 10px;"
+            style="margin-left: 10px;"
           >
-            {{ __("Hide") }}
+          👁️ {{ __("Hide") }}
           </button>
         </div>
         
@@ -25,7 +25,7 @@
           {{ outstanding_amount }}
         </div>
         <div class="col-sm-2 ellipsis hidden-xs">{{ posting_date }}</div>
-        <div class="col-sm-3 ellipsis">{{ due_date }}</div>
+        <!-- <div class="col-sm-3 ellipsis">{{ due_date }}</div> -->
       </div>
     </div>
   </div>
@@ -56,9 +56,9 @@
       {{ payment.unallocated_amount }} {{ currency }}
     </div>
     <div class="col-sm-2 ellipsis">{{ payment.posting_date }}</div>
-    <div class="col-sm-3 ellipsis hidden-xs" style="white-space: normal">
+    <!-- <div class="col-sm-3 ellipsis hidden-xs" style="white-space: normal">
       {{ payment.remarks}}
-    </div>
+    </div> -->
 
   </div>
 </div>
@@ -68,13 +68,13 @@
 {% if optionValue == "Bank Transaction" %} {% for payment in payments %}
 <div class="list-row payment-assign-wizard-item" style="height: auto">
   <div class="row">
-    <div class="col-sm-1" style="padding-right: 0px">
+    <div class="col-sm-2" style="padding-right: 0px">
       <button
         class="reconcile_transaction btn btn-default btn-xs center-block"
         data-name="{{ payment.name }}"
-        style="padding-top: 0px; padding-bottom: 0px"
+        style="margin-left: 10px;"
       >
-        {{ __("Reconcile") }}
+      💰 {{ __("Reconcile") }}
       </button>
     </div>
 
@@ -93,9 +93,9 @@
     </div>
     <div class="col-sm-2 ellipsis">{{ payment.date }}</div>
 
-    <div class="col-sm-2 ellipsis">
+    <!-- <div class="col-sm-2 ellipsis">
       <a href="bank-transaction/{{ payment.name }}">{{ payment.name }}</a>
-    </div>
+    </div> -->
 
   </div>
 </div>

--- a/erpnextfints/erpnextfints/page/bank_transaction_wiz/bank_transaction_wiz.css
+++ b/erpnextfints/erpnextfints/page/bank_transaction_wiz/bank_transaction_wiz.css
@@ -1,0 +1,14 @@
+.list-row-contain {
+    border: 1px solid #ccc;
+    border-radius: 5px;
+    margin-bottom: 10px;
+    padding: 10px;
+}
+
+.list-row-contain:nth-of-type(odd) {
+    background-color: #F3F3F3;
+}
+
+.list-row-contain:nth-of-type(even) {
+    background-color: #FFFFFF;
+}

--- a/erpnextfints/erpnextfints/page/bank_transaction_wiz/bank_transaction_wiz.js
+++ b/erpnextfints/erpnextfints/page/bank_transaction_wiz/bank_transaction_wiz.js
@@ -17,12 +17,14 @@ erpnextfints.tools.assignWizard = class assignWizard {
 		});
 		this.parent = wrapper;
 		this.page = this.parent.page;
+		this.remove_page_buttons();
 		this.make();
 	}
-
+	remove_page_buttons(){
+		$('.custom-actions').remove()
+	}
 	make() {
 		const me = this;
-
 		me.clear_page_content();
 		me.make_assignWizard_tool();
 		me.add_actions();
@@ -225,16 +227,13 @@ erpnextfints.tools.AssignWizardTool = class AssignWizardTool extends (
 		$('[data-fieldname="name"]').remove();
 		$('[data-fieldname="status"]').remove();
 		$('[data-fieldname="title"]').remove();
-		let index = 0;
+		
 		let rowHTML;
 
 		// me.data - list of sales invoice. the below code fetchs all payment entries(Payment Entry and Bank Transaction) associated with single sales invoice
 
 		for (const value of me.data) {
-			rowHTML =
-				index % 2 !== 0
-					? '<div class="list-row-container" style="background-color: #F3F3F3">'
-					: '<div class="list-row-container">';
+			rowHTML = '<div class="list-row-contain"></div>';
 
 			const r = await frappe.call(
 				this.get_row_call_args(value.customer, optionValue)
@@ -251,7 +250,6 @@ erpnextfints.tools.AssignWizardTool = class AssignWizardTool extends (
 					optionValue
 				);
 			}
-			index += 1;
 		}
 	}
 
@@ -331,7 +329,7 @@ erpnextfints.tools.AssignWizardRow = class AssignWizardRow {
 							vouchers: vouchers,
 						},
 						callback(/* r */) {
-							// Refresh page after asignment
+							// Refresh page after asignment					
 							erpnextfints.tools.assignWizardList.refresh();
 						},
 					});


### PR DESCRIPTION
- removed the view switcher
- make the column name "Party" rather than "Customer"
- merged the two date column in to one
- Hide/Reconcile buttons are now big and also have emoji/Icon
- added a frame for entries belonging to each other

![image](https://github.com/phamos-eu/kefiya/assets/71070205/d2585757-78d7-4e55-b79f-048593152263)

![image](https://github.com/phamos-eu/kefiya/assets/71070205/edfb8a0b-fb36-4286-a1fd-7788456d2962)
