### PR TITLE
create payment entry during reconciliation

### DIFF
--- a/erpnextfints/erpnextfints/page/bank_transaction_wiz/bank_transaction_header.html
+++ b/erpnextfints/erpnextfints/page/bank_transaction_wiz/bank_transaction_header.html
@@ -9,7 +9,7 @@
   <div class="level list-row list-row-head text-muted small">
     <div class="col-sm-2 ellipsis">{{ __("Action") }}</div>
     <div class="col-sm-2 ellipsis">{{ __("Name") }}</div>
-    <div class="col-sm-2 ellipsis hidden-xs">{{ __("Customer") }}</div>
+    <div class="col-sm-2 ellipsis hidden-xs">{{ __("Party") }}</div>
     <div class="col-sm-2 ellipsis hidden-xs">
       {{ __("Outstanding Amount") }}
     </div>

--- a/erpnextfints/erpnextfints/page/bank_transaction_wiz/bank_transaction_row.html
+++ b/erpnextfints/erpnextfints/page/bank_transaction_wiz/bank_transaction_row.html
@@ -80,6 +80,8 @@
 
     <div class="col-sm-2 ellipsis hidden-xs" style="white-space: normal">
       {{ payment.description}}
+      <!-- <br>
+      <a href="bank-transaction/{{ payment.name }}">{{ payment.name }}</a> -->
     </div>
 
     <div class="col-sm-2 ellipsis hidden-xs">

--- a/erpnextfints/erpnextfints/page/bank_transaction_wiz/bank_transaction_wiz.js
+++ b/erpnextfints/erpnextfints/page/bank_transaction_wiz/bank_transaction_wiz.js
@@ -191,6 +191,7 @@ erpnextfints.tools.AssignWizardTool = class AssignWizardTool extends (
 				docstatus: 1,
 				party: customer,
 				unallocated_amount: [">", 0],
+				deposit: [">", 0]
 			};
 			order_by = "date";
 		} else {
@@ -320,7 +321,7 @@ erpnextfints.tools.AssignWizardRow = class AssignWizardRow {
 			const bank_transaction_name = $(this).attr("data-name");
 			
 			frappe.call({
-				method: "erpnextfints.utils.client.add_sales_invoice_payment",
+				method: "erpnextfints.utils.client.create_payment_entry",
 				args: {
 					bank_transaction_name: bank_transaction_name,
 					sales_invoice_name: sales_invoice_name,
@@ -328,11 +329,12 @@ erpnextfints.tools.AssignWizardRow = class AssignWizardRow {
 				callback: function (r) {
 					let vouchers = [];
 
-					const paid_amount = r.message;
+					const paid_amount = r.message[0];
+					const payment_entry_name = r.message[1];
 
 					vouchers.push({
-						payment_doctype: "Sales Invoice",
-						payment_name: sales_invoice_name,
+						payment_doctype: "Payment Entry",
+						payment_name: payment_entry_name,
 						amount: format_currency(paid_amount, currency),
 					});
 					


### PR DESCRIPTION
When the "Reconcile" button is clicked on the Bank Transaction Wizard page, the system performs the following steps:

1, Create a Payment Entry Record
- The system generates a payment entry record based on the bank transaction details.
- It updates the outstanding amount and status of the sales invoice to either "Paid" or "Partially Paid" depending on the payment amount.

2, Reconcile the Bank Transaction
- The system reconciles the bank transaction record with the created payment entry record(which linked with the sales invoice).

In general, the sales invoice amount is updated by the payment entry, and the payment entry is cleared by the bank transaction.
 
![bank_transaction_wizard](https://github.com/phamos-eu/kefiya/assets/71070205/5e558fbf-9e76-47ed-9238-57ae8994b0b5)
