### PR TITLE
feat: select button added on bank transaction wizard page

### DIFF
--- a/erpnextfints/erpnextfints/doctype/kefiya_settings/kefiya_settings.json
+++ b/erpnextfints/erpnextfints/doctype/kefiya_settings/kefiya_settings.json
@@ -26,6 +26,7 @@
   {
    "fieldname": "assign_against",
    "fieldtype": "Select",
+   "hidden": 1,
    "label": "Match Against",
    "options": "Sales Invoice\nPurchase Invoice"
   }
@@ -33,7 +34,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2024-06-17 12:55:34.332563",
+ "modified": "2024-06-18 16:34:12.837293",
  "modified_by": "Administrator",
  "module": "ERPNextFinTS",
  "name": "Kefiya Settings",

--- a/erpnextfints/erpnextfints/page/bank_transaction_wiz/bank_transaction_wiz.js
+++ b/erpnextfints/erpnextfints/page/bank_transaction_wiz/bank_transaction_wiz.js
@@ -19,10 +19,12 @@ erpnextfints.tools.assignWizard = class assignWizard {
 		this.page = this.parent.page;
 		this.remove_page_buttons();
 		this.make();
+		this.add_custom()
 	}
 	remove_page_buttons(){
-		$('.custom-actions').remove()
+		// $('.custom-actions').remove()
 		$('.page-form').remove();	
+		$('.menu-btn-group').remove()
 	}
 
 	async fetchKefiyaSettings() {
@@ -38,10 +40,32 @@ erpnextfints.tools.assignWizard = class assignWizard {
 
 	async make() {
 		const me = this;
+		me.page.hide_icon_group();
 		me.clear_page_content();
 		let result = await this.fetchKefiyaSettings()
 		me.make_assignWizard_tool(result);
 		// me.add_actions();
+	}
+
+	add_custom(){
+		// add a dropdown button in a group
+		const me = this;
+		me.page.add_inner_button('Sales Invoice', () => this.change_match_against('Sales Invoice'), 'Match Against')
+		me.page.add_inner_button('Purchase Invoice', () => this.change_match_against('Purchase Invoice'), 'Match Against')		
+	}
+
+	change_match_against(selected_match){
+		const me = this;
+		frappe.call({
+			method: "erpnextfints.utils.client.change_match_against",
+			args: {
+				selected_match: selected_match
+			},
+			callback: function (r) {
+				me.make()
+			}
+		});
+
 	}
 
 	add_actions() {
@@ -277,6 +301,9 @@ erpnextfints.tools.AssignWizardTool = class AssignWizardTool extends (
 		$('[data-fieldname="name"]').remove();
 		$('[data-fieldname="status"]').remove();
 		$('[data-fieldname="title"]').remove();
+		$('[data-original-title="Refresh"]').remove();
+		$('.custom-btn-group').remove()
+		
 		
 		let rowHTML;
 		let party_value;

--- a/erpnextfints/utils/client.py
+++ b/erpnextfints/utils/client.py
@@ -174,3 +174,9 @@ def create_payment_entry(bank_transaction_name, invoice_name, match_against):
     payment_entry.submit()
 
     return paid_amount, payment_entry.name
+
+@frappe.whitelist()
+def change_match_against(selected_match):
+    kefiya_setting = frappe.get_single("Kefiya Settings")
+    kefiya_setting.assign_against = selected_match
+    kefiya_setting.save()


### PR DESCRIPTION
a select button is added on bank transaction wizard page to swap between sales invoice and purchase invoice during reconciliation.

![match_against_button](https://github.com/phamos-eu/kefiya/assets/71070205/e4e5b96b-f61f-4968-af0e-b0df6e675bf3)
