### PR TITLE
feature: 78-payment-request-export-functionality

### DIFF
--- a/kefiya/events/hammer_script/payment_request_on_submit.py
+++ b/kefiya/events/hammer_script/payment_request_on_submit.py
@@ -1,51 +1,43 @@
 import frappe
 from frappe.utils import flt
 from datetime import datetime
+from frappe import _
+import io
 
-def export_request(doc,method):
-    filename = "/tmp/payment_request_on_submit.log"
+@frappe.whitelist()
+def export_request(payment_request_name):
     
-    with open(filename, "a") as f:
-        f.write(f"{doc.doctype} | {doc.name} | {method} | start hook\n")
-        f.write(f"{doc.doctype} | {doc.name} | {method} | {str(doc.as_dict())}\n")
-  
-    paymentrequest = frappe.get_doc("Payment Request", doc.name)
-    partybankaccount = frappe.get_doc("Bank Account", doc.party_bank_account)
-    bankaccount = frappe.get_doc("Bank Account", doc.bank_account)
-    invoicedoc = frappe.get_doc(doc.reference_doctype, doc.reference_name)
+    buffer = io.StringIO()
 
-    moneyfile = "/tmp/moneyplex_" + doc.name + ".csv"
+    hdrtext =   "Kontoname;" + \
+                "Kontonummer;" + \
+                "Bankleitzahl;" + \
+                "Datum;" + \
+                "Valuta;" + \
+                "Name;" + \
+                "Iban;" + \
+                "Bic;" + \
+                "Zweck;" + \
+                "Kategorie;" + \
+                "Betrag;" + \
+                "Währung\n"
+    buffer.write(hdrtext)
 
-    try:
-        with open(moneyfile, "r"):
-            pass
-    except:
-        with open(moneyfile, "a") as m:
-            hdrtext =   "Kontoname;" + \
-                        "Kontonummer;" + \
-                        "Bankleitzahl;" + \
-                        "Datum;" + \
-                        "Valuta;" + \
-                        "Name;" + \
-                        "Iban;" + \
-                        "Bic;" + \
-                        "Zweck;" + \
-                        "Kategorie;" + \
-                        "Betrag;" + \
-                        "Währung" + \
-                        u"\n"
-            m.write(hdrtext)  
-    
     def safe_format(value):
         return f'"{value}"' if value is not None else ""
 
-    with open(moneyfile, "a") as m:
+    try:
+        doc = frappe.get_doc("Payment Request", payment_request_name)
+        partybankaccount = frappe.get_doc("Bank Account", doc.party_bank_account)
+        bankaccount = frappe.get_doc("Bank Account", doc.bank_account)
+        invoicedoc = frappe.get_doc(doc.reference_doctype, doc.reference_name)
+
         postext = f'{safe_format(doc.company)};'
         postext += f'{safe_format(bankaccount.iban)};'
         postext += f'{safe_format(bankaccount.branch_code)};'
 
         if doc.transaction_date:
-            date_obj = datetime.strptime(doc.transaction_date, '%Y-%m-%d')
+            date_obj = datetime.strptime(str(doc.transaction_date), '%Y-%m-%d')
             formatted_date = date_obj.strftime('%d.%m.%Y')
             date = f'{formatted_date}'
             
@@ -56,11 +48,10 @@ def export_request(doc,method):
         postext += f'{safe_format(doc.party)};'
         postext += f'{safe_format(partybankaccount.iban)};'
         postext += f'{safe_format(partybankaccount.branch_code)};'
-        
+
         if doc.payment_request_type == "Outward":
             bill_no = invoicedoc.bill_no if doc.reference_doctype == "Purchase Invoice" else ""
             postext += f'"Rechnung {bill_no if bill_no else doc.name}";'
-
         elif doc.payment_request_type == "Inward":
             postext += f'"Lastschrift {doc.name}";'
 
@@ -72,4 +63,41 @@ def export_request(doc,method):
             postext += f'"{frappe.format(-flt(invoicedoc.grand_total), {"fieldtype": "Float"})}";'
 
         postext += f'{safe_format(doc.currency)}\n'
-        m.write(postext)
+        buffer.write(postext)
+
+        settings = frappe.get_single("Kefiya Settings")
+
+        return {
+            "status": "success",
+            "csv_action": settings.payment_request_csv_action,
+            "recipient_email": settings.recipient_email,
+            "data": buffer.getvalue()
+        }
+
+    except Exception as e:
+        return {"status": "error", "message": str(e)}
+
+
+@frappe.whitelist()
+def send_csv_via_email(recipient_email, csv_content):
+    try:
+        subject = _("Your CSV File")
+        message = _("Please find the attached CSV file.")
+        
+        attachments = [{
+            "fname": "moneyplex_request.csv",
+            "fcontent": csv_content,
+        }]
+        
+        frappe.sendmail(
+            recipients=[recipient_email],
+            subject=subject,
+            message=message,
+            attachments=attachments,
+            delayed=False,
+            retry=3
+        )
+
+        return {"status": "success", "message": _("Email sent successfully.")}
+    except Exception as e:
+        return {"status": "error", "message": str(e)}

--- a/kefiya/events/hammer_script/payment_request_on_submit.py
+++ b/kefiya/events/hammer_script/payment_request_on_submit.py
@@ -81,7 +81,7 @@ def export_request(payment_request_name):
 @frappe.whitelist()
 def send_csv_via_email(recipient_email, csv_content):
     try:
-        subject = _("Your CSV File")
+        subject = _("Moneyplex CSV File")
         message = _("Please find the attached CSV file.")
         
         attachments = [{

--- a/kefiya/hooks.py
+++ b/kefiya/hooks.py
@@ -39,12 +39,6 @@ app_license = "MIT"
 doctype_js = {
 	"Payment Request": "public/js/payment_request.js"
 }
-
-doc_events = {
-    "Payment Request": {
-        "on_submit": "kefiya.events.hammer_script.payment_request_on_submit.export_request",
-	},
-}
 # doctype_js = {"doctype" : "public/js/doctype.js"}
 # doctype_list_js = {"doctype" : "public/js/doctype_list.js"}
 # doctype_tree_js = {"doctype" : "public/js/doctype_tree.js"}

--- a/kefiya/kefiya/doctype/kefiya_settings/kefiya_settings.json
+++ b/kefiya/kefiya/doctype/kefiya_settings/kefiya_settings.json
@@ -5,10 +5,15 @@
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
+  "bank_account",
   "assign_against",
   "show_entries_in_payment_assignment_wizard",
+  "submit_payment_entry",
+  "column_break_gv35w",
   "mode_of_payment",
-  "submit_payment_entry"
+  "column_break_qzdrd",
+  "payment_request_csv_action",
+  "recipient_email"
  ],
  "fields": [
   {
@@ -36,12 +41,42 @@
    "fieldname": "submit_payment_entry",
    "fieldtype": "Check",
    "label": "Submit Payment Entry"
+  },
+  {
+   "fieldname": "column_break_qzdrd",
+   "fieldtype": "Section Break",
+   "label": "Payment Request Export"
+  },
+  {
+   "fieldname": "payment_request_csv_action",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "label": "Payment Request CSV Action",
+   "options": "Download CSV\nSend CSV via Email",
+   "reqd": 1
+  },
+  {
+   "depends_on": "eval:doc.payment_request_csv_action == 'Send CSV via Email';",
+   "fieldname": "recipient_email",
+   "fieldtype": "Data",
+   "label": "Recipient Email",
+   "mandatory_depends_on": "eval:doc.payment_request_csv_action == 'Send CSV via Email';",
+   "options": "Email"
+  },
+  {
+   "fieldname": "column_break_gv35w",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "bank_account",
+   "fieldtype": "Section Break",
+   "label": "Bank Transaction Wizard"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2024-08-28 13:49:13.835163",
+ "modified": "2024-09-23 17:49:10.999958",
  "modified_by": "Administrator",
  "module": "Kefiya",
  "name": "Kefiya Settings",

--- a/kefiya/public/js/payment_request.js
+++ b/kefiya/public/js/payment_request.js
@@ -1,29 +1,98 @@
 frappe.ui.form.on('Payment Request', {
-	refresh: function(frm) {
-		frm.set_df_property('transaction_date', 'reqd', 1);
-		frm.set_df_property('company', 'reqd', 1);
-		frm.set_df_property('bank_account', 'reqd', 1);
-		frm.set_df_property('party_bank_account', 'reqd', 1);
+    refresh: function(frm) {
+        frm.set_df_property('transaction_date', 'reqd', 1);
+        frm.set_df_property('company', 'reqd', 1);
+        frm.set_df_property('bank_account', 'reqd', 1);
+        frm.set_df_property('party_bank_account', 'reqd', 1);
     },
 
     setup: function(frm) {
-		frm.set_query("party_bank_account", function() {
-			return {
-				filters: {
-					is_company_account: 0,
-					party_type: frm.doc.party_type,
-					party: frm.doc.party
-				}
-			}
-		});
+        frm.set_query("party_bank_account", function() {
+            return {
+                filters: {
+                    is_company_account: 0,
+                    party_type: frm.doc.party_type,
+                    party: frm.doc.party
+                }
+            }
+        });
 
-		frm.set_query("bank_account", function() {
-			return {
-				filters: {
-					is_company_account: 1,
-					company: frm.doc.company
-				}
-			}
-		});	
-	},
-})
+        frm.set_query("bank_account", function() {
+            return {
+                filters: {
+                    is_company_account: 1,
+                    company: frm.doc.company
+                }
+            }
+        });
+    },
+
+    before_submit: function(frm) {
+
+        frappe.call({
+            method: "kefiya.events.hammer_script.payment_request_on_submit.export_request",
+            args: {
+                payment_request_name: frm.doc.name
+            },
+            callback: function(r) {
+                if (r.message.status == "success") {
+                    if (r.message.csv_action == "Download CSV"){
+						var csvContent = r.message.data;
+						var blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
+
+						var link = document.createElement("a");
+						if (link.download !== undefined) {
+							var url = URL.createObjectURL(blob);
+							link.setAttribute("href", url);
+							link.setAttribute("download", "moneyplex_" + frm.doc.name + ".csv");
+							link.style.visibility = 'hidden';
+							document.body.appendChild(link);
+							link.click();
+							document.body.removeChild(link);
+						}
+					}
+					else if (r.message.csv_action == "Send CSV via Email") {
+
+						const recipient_email = r.message.recipient_email;
+						const csv_content = r.message.data;
+
+                        frappe.msgprint({
+                            title: __('Sending Email'),
+                            indicator: 'blue',
+                            message: __('Email is being sent to {0}. Please wait...', [recipient_email])
+                        });
+
+						frappe.call({
+							method: "kefiya.events.hammer_script.payment_request_on_submit.send_csv_via_email",
+							args: {
+								recipient_email,
+								csv_content
+							},
+							callback: function (r) {
+								
+								if (r.message) {
+									if (r.message.status === "success") {
+										frappe.show_alert({
+                                            message: __('Email sent successfully to {0}', [recipient_email]),
+                                            indicator: 'green'
+                                        });
+									} else {
+										frappe.msgprint({
+											title: __('Error'),
+											indicator: 'red',
+											message: r.message.message
+										});
+										frappe.validated = false;
+									}
+								}
+							}
+						})
+					}
+                } else {
+					frappe.msgprint(__('Error during CSV export: {0}', [r.message.message]));
+					frappe.validated = false;
+                }
+            }
+        });
+    }
+});


### PR DESCRIPTION
- Task: [#78](https://git.phamos.eu/gallehr/kefiya/-/work_items/78)
- Added `Payment Request Export` section on `Kefiya Settings`  which holds configuration for the moneplex csv file export.

![Screenshot from 2024-09-23 19-12-45](https://github.com/user-attachments/assets/5ea24a84-12fd-46af-b653-9502f9b92774)

- Added two options for accessing the csv file
     - Download CSV: which downloads the csv file once we submit the Payment Request document.
     - Send CSV via Email: which send the csv file as attachment to the specified recipient email on Kefiya Settings
- Removed the code that saves the csv file on the server which reduce memory cost.

![payment_request_moneyplex](https://github.com/user-attachments/assets/4be66b8c-b171-42cb-a88a-c0937470ce62)

