### PR TITLE
fix/89-bank-account-wizard

### DIFF
--- a/kefiya/kefiya/page/bank_account_wizard/bank_account_wizard.css
+++ b/kefiya/kefiya/page/bank_account_wizard/bank_account_wizard.css
@@ -1,4 +1,3 @@
 .list-row-contain {
-    margin-bottom: 20px;
     padding: 10px;
 }

--- a/kefiya/kefiya/page/bank_account_wizard/bank_account_wizard_row.html
+++ b/kefiya/kefiya/page/bank_account_wizard/bank_account_wizard_row.html
@@ -16,7 +16,7 @@
 				<div class="ellipsis">{{ deposit }} / {{withdrawal}}</div>
 			</div>
 		</div>
-		<div class="col-sm-2 ellipsis hidden-xs" style="white-space: normal">
+		<div class="col-sm-2 ellipsis hidden-xs">
 			{{ description }}
 		</div>
 		<div class="col-sm-3 hidden-xs">


### PR DESCRIPTION
Task: [#89](https://git.phamos.eu/gallehr/kefiya/-/work_items/89#note_7097)

- Limit the character length of the `Description` column to avoid text overlapping. 

![image](https://github.com/user-attachments/assets/1ff4c7d9-8103-4028-ba74-cf040acf83ea)
