### PR TITLE
fix: 89-bank-account-wizard

### DIFF
--- a/kefiya/kefiya/page/bank_transaction_wiz/bank_transaction_row.html
+++ b/kefiya/kefiya/page/bank_transaction_wiz/bank_transaction_row.html
@@ -47,98 +47,113 @@
 </div>
 {% endif %}
 
-<!-- Payment Entries -->
-{% if optionValue == "Payment Entry" %} {% for payment in payments %}
-<div class="list-row payment-assign-wizard-item" style="height: auto">
-  <div class="row">
-    <div class="col-sm-1" style="padding-right: 0px">
-      <button
-        class="assign_payment btn btn-default btn-xs center-block"
-        data-name="{{ payment.name }}"
-        style="padding-top: 0px; padding-bottom: 0px"
-      >
-        {{ __("Assign") }}
-      </button>
-    </div>
-    <div class="col-sm-2 ellipsis">
-      <a href="payment-entry/{{ payment.name }}">{{ payment.name }}</a>
-    </div>
-    <div class="col-sm-2 ellipsis hidden-xs">
-      {{ payment.party }}
-      <br>
-      {% if matchAgainst === "Sales Invoice" %}
-        {{customer_name}}
-      {% endif %}
 
-      {% if matchAgainst === "Purchase Invoice" %}
-        {{supplier_name}}
-      {% endif %}
-    </div>
-    <div class="col-sm-2 ellipsis">
-      {{ payment.unallocated_amount }} {{ currency }}
-    </div>
-    <div class="col-sm-2 ellipsis">{{ payment.posting_date }}</div>
-    <!-- <div class="col-sm-3 ellipsis hidden-xs" style="white-space: normal">
-      {{ payment.remarks}}
-    </div> -->
-
-  </div>
-</div>
-{% endfor %} {% endif %}
-
-<!-- Bank Transactions -->
-{% if optionValue == "Bank Transaction" %} {% for payment in payments %}
+{% if matchAgainst === "Journal Entry" %}
 <div class="list-row payment-assign-wizard-item" style="height: auto">
   <div class="row">
     <div class="col-sm-2" style="padding-right: 0px">
-      {% if matchAgainst === "Sales Invoice" || matchAgainst === "Purchase Invoice" %}
-        <button
-          class="reconcile_transaction btn btn-default btn-xs center-block"
-          data-name="{{ payment.name }}"
-          style="margin-left: 10px;"
-        >
-        💰 {{ __("Reconcile") }}
-        </button>
-      {% endif %}
-
-      {% if matchAgainst === "Journal Entry"%}
       <button
         class="create_journal_entry btn btn-default btn-xs center-block"
-        data-name="{{ payment.name }}"
+        data-name="{{ name }}"
         style="margin-left: 10px;"
       >
       💰 {{ __("Create") }}
       </button>
-    {% endif %}
     </div>
 
     <div class="col-sm-2 ellipsis hidden-xs" style="white-space: normal">
-      {{ payment.description}}
+      {{ description }}
       <br>
-      <a href="bank-transaction/{{ payment.name }}">{{ payment.name }}</a>
+      <a href="bank-transaction/{{ name }}">{{ name }}</a>
     </div>
 
     <div class="col-sm-2 ellipsis hidden-xs">
-      {{ payment.party }}
-      <br>
-      {% if matchAgainst === "Sales Invoice" %}
-        {{customer_name}}
-      {% endif %}
-
-      {% if matchAgainst === "Purchase Invoice" %}
-        {{supplier_name}}
-      {% endif %}
+      {{ party }}
     </div>
     <div class="col-sm-2 ellipsis">
-      
-      {{ payment.unallocated_amount }}
+      {{ unallocated_amount }}
     </div>
-    <div class="col-sm-2 ellipsis">{{ payment.date }}</div>
-
-    <!-- <div class="col-sm-2 ellipsis">
-      <a href="bank-transaction/{{ payment.name }}">{{ payment.name }}</a>
-    </div> -->
-
+    <div class="col-sm-2 ellipsis"> {{ date }}</div>
   </div>
 </div>
-{% endfor %} {% endif %}
+{% else %}
+
+
+<!-- Payment Entries -->
+{% if optionValue == "Payment Entry" %}
+  {% for payment in payments %}
+    <div class="list-row payment-assign-wizard-item" style="height: auto">
+      <div class="row">
+        <div class="col-sm-1" style="padding-right: 0px">
+          <button
+            class="assign_payment btn btn-default btn-xs center-block"
+            data-name="{{ payment.name }}"
+            style="padding-top: 0px; padding-bottom: 0px"
+          >
+            {{ __("Assign") }}
+          </button>
+        </div>
+        <div class="col-sm-2 ellipsis">
+          <a href="payment-entry/{{ payment.name }}">{{ payment.name }}</a>
+        </div>
+        <div class="col-sm-2 ellipsis hidden-xs">
+          {{ payment.party }}
+          <br>
+          {% if matchAgainst === "Sales Invoice" %}
+            {{customer_name}}
+          {% endif %}
+
+          {% if matchAgainst === "Purchase Invoice" %}
+            {{supplier_name}}
+          {% endif %}
+        </div>
+        <div class="col-sm-2 ellipsis">
+          {{ payment.unallocated_amount }} {{ currency }}
+        </div>
+        <div class="col-sm-2 ellipsis">{{ payment.posting_date }}</div>
+      </div>
+    </div>
+  {% endfor %} 
+{% endif %}
+
+<!-- Bank Transactions -->
+{% if  optionValue == "Bank Transaction" %} 
+    {% for payment in payments %}
+      <div class="list-row payment-assign-wizard-item" style="height: auto">
+        <div class="row">
+          <div class="col-sm-2" style="padding-right: 0px">
+              <button
+                class="reconcile_transaction btn btn-default btn-xs center-block"
+                data-name="{{ payment.name }}"
+                style="margin-left: 10px;"
+              >
+              💰 {{ __("Reconcile") }}
+              </button>
+          </div>
+          <div class="col-sm-2 ellipsis hidden-xs" style="white-space: normal">
+            {{ payment.description}}
+            <br>
+            <a href="bank-transaction/{{ payment.name }}">{{ payment.name }}</a>
+          </div>
+          <div class="col-sm-2 ellipsis hidden-xs">
+            {{ payment.party }}
+            <br>
+            {% if matchAgainst === "Sales Invoice" %}
+              {{customer_name}}
+            {% endif %}
+
+            {% if matchAgainst === "Purchase Invoice" %}
+              {{supplier_name}}
+            {% endif %}
+          </div>
+          <div class="col-sm-2 ellipsis">
+            {{ payment.unallocated_amount }}
+          </div>
+          <div class="col-sm-2 ellipsis">
+            {{ payment.date }}
+          </div>
+        </div>
+      </div>
+    {% endfor %} 
+  {% endif %}
+{% endif %}


### PR DESCRIPTION
- Task: [#84](https://git.phamos.eu/gallehr/kefiya/-/issues/84?show=1151)
- Made a tab view of the options in `Bank Transaction Wizard` page and removed the `Match Against` dropdown.

![tab_view](https://github.com/user-attachments/assets/298620bd-3312-4714-82ac-30df26ce08aa)

- Task: [84](https://git.phamos.eu/gallehr/kefiya/-/issues/84?show=1155)
- On `Bank Transaction Wizard` page entries in journal entry tab can go beyond 20 by clicking on `Load More` button.

![pagination](https://github.com/user-attachments/assets/af425e3e-e051-4980-8b95-3b98a3868464)
