### PR TITLE
fix/72-bank-transaction-wizard

### DIFF
--- a/kefiya/kefiya/page/bank_transaction_wiz/bank_transaction_row.html
+++ b/kefiya/kefiya/page/bank_transaction_wiz/bank_transaction_row.html
@@ -98,14 +98,6 @@
         </div>
         <div class="col-sm-2 ellipsis hidden-xs">
           {{ payment.party }}
-          <br>
-          {% if matchAgainst === "Sales Invoice" %}
-            {{customer_name}}
-          {% endif %}
-
-          {% if matchAgainst === "Purchase Invoice" %}
-            {{supplier_name}}
-          {% endif %}
         </div>
         <div class="col-sm-2 ellipsis">
           {{ payment.unallocated_amount }} {{ currency }}
@@ -137,14 +129,6 @@
           </div>
           <div class="col-sm-2 ellipsis hidden-xs">
             {{ payment.party }}
-            <br>
-            {% if matchAgainst === "Sales Invoice" %}
-              {{customer_name}}
-            {% endif %}
-
-            {% if matchAgainst === "Purchase Invoice" %}
-              {{supplier_name}}
-            {% endif %}
           </div>
           <div class="col-sm-2 ellipsis">
             {{ payment.unallocated_amount }}

--- a/kefiya/kefiya/page/bank_transaction_wiz/bank_transaction_wiz.js
+++ b/kefiya/kefiya/page/bank_transaction_wiz/bank_transaction_wiz.js
@@ -328,8 +328,8 @@ kefiya.tools.AssignWizardTool = class AssignWizardTool extends (
 			filters = {
 				docstatus: 1,
 				unallocated_amount: [">", 0],
-				...(matchAgainst === "Sales Invoice" ? { deposit: [">", 0] } : {}),
-				...(matchAgainst === "Purchase Invoice" ? { withdrawal: [">", 0] } : {})
+				...(matchAgainst === "Sales Invoice" ? { party, deposit: [">", 0] } : {}),
+				...(matchAgainst === "Purchase Invoice" ? { party, withdrawal: [">", 0] } : {})
 			};
 			order_by = "date";
 		} else {


### PR DESCRIPTION
- Task: [#96](https://git.phamos.eu/gallehr/kefiya/-/work_items/96)
- Added a filter to display bank transactions that much with the sales invoice using `party` field.
- Removed the unnecessary name tag on the bank transaction row.

Before

![Screenshot from 2024-10-17 12-09-51](https://github.com/user-attachments/assets/f83d898d-3bf5-4e40-b6a8-4dab88bea590)

After

![image](https://github.com/user-attachments/assets/8a993bb8-6acf-4744-9529-3c6166029e40)
