### PR TITLE
fix/80-refresh-icon-bug

### DIFF
--- a/kefiya/kefiya/page/bank_transaction_wiz/bank_transaction_wiz.js
+++ b/kefiya/kefiya/page/bank_transaction_wiz/bank_transaction_wiz.js
@@ -359,6 +359,7 @@ kefiya.tools.AssignWizardTool = class AssignWizardTool extends (
 		$('[data-fieldname="status"]').remove();
 		$('[data-fieldname="title"]').remove();
 		$('[data-original-title="Refresh"]').remove();
+		$('[data-original-title="Reload List"]').remove();
 		$('.custom-btn-group').remove()
 		
 		let rowHTML;


### PR DESCRIPTION
- Task: [#80](https://git.phamos.eu/gallehr/kefiya/-/issues/80)
- Resolved the issue where a refresh icon was added each time the user switched tabs in the Bank Transaction Wizard. This occurred because, in the next Frappe release, the icon name changed from `Refresh` to `Reload List`.