### PR TITLE
fix/54-switch-party-and-company-bank-accounts

### DIFF
--- a/kefiya/events/hammer_script/payment_request_on_submit.py
+++ b/kefiya/events/hammer_script/payment_request_on_submit.py
@@ -28,8 +28,8 @@ def export_request(payment_request_name):
 
     try:
         doc = frappe.get_doc("Payment Request", payment_request_name)
-        partybankaccount = frappe.get_doc("Bank Account", doc.party_bank_account)
-        bankaccount = frappe.get_doc("Bank Account", doc.bank_account)
+        partybankaccount = frappe.get_doc("Bank Account", doc.bank_account)
+        bankaccount = frappe.get_doc("Bank Account", doc.company_bank_account)
         invoicedoc = frappe.get_doc(doc.reference_doctype, doc.reference_name)
         partydoc = frappe.get_doc(doc.party_type, doc.party)
         partyname = (

--- a/kefiya/public/js/payment_request.js
+++ b/kefiya/public/js/payment_request.js
@@ -3,16 +3,15 @@ frappe.ui.form.on('Payment Request', {
         frm.set_df_property('transaction_date', 'reqd', 1);
         frm.set_df_property('company', 'reqd', 1);
         frm.set_df_property('bank_account', 'reqd', 1);
-        frm.set_df_property('party_bank_account', 'reqd', 1);
+        frm.set_df_property('company_bank_account', 'reqd', 1);
     },
 
     setup: function(frm) {
-        frm.set_query("party_bank_account", function() {
+        frm.set_query("company_bank_account", function() {
             return {
                 filters: {
-                    is_company_account: 0,
-                    party_type: frm.doc.party_type,
-                    party: frm.doc.party
+                    is_company_account: 1,
+                    company: frm.doc.company
                 }
             }
         });
@@ -20,8 +19,9 @@ frappe.ui.form.on('Payment Request', {
         frm.set_query("bank_account", function() {
             return {
                 filters: {
-                    is_company_account: 1,
-                    company: frm.doc.company
+                    is_company_account: 0,
+                    party_type: frm.doc.party_type,
+                    party: frm.doc.party
                 }
             }
         });

--- a/kefiya/setup/install.py
+++ b/kefiya/setup/install.py
@@ -41,17 +41,16 @@ def get_custom_fields():
 			"insert_after": "company",
 		},
 		{
-			"label": "Party Bank Account",
-			"fieldname": "party_bank_account",
+			"label": "Company Bank Account",
+			"fieldname": "company_bank_account",
 			"fieldtype": "Link",
             "options": "Bank Account",
-            "depends_on": "party",
 			"insert_after": "kefiya_section",
 		},
 		{
 			"fieldname": "kefiya_last_section",
 			"fieldtype": "Section Break",
-			"insert_after": "party_bank_account"
+			"insert_after": "company_bank_account"
 		}
 	]
 


### PR DESCRIPTION
- Task: [#54](https://git.phamos.eu/gallehr/gallehr/-/work_items/54#note_9660)
- Used `Bank Account` as a party bank account

![image](https://github.com/user-attachments/assets/b6178bb0-b394-4f78-9072-2bbdf9a1811c)

- Created a `Company Bank Account` custom field

![Screenshot from 2024-11-26 18-53-15](https://github.com/user-attachments/assets/9dd24ab9-9f28-4aee-94e2-44a5ab347c7c)

- Removed the `Party Bank Account` custom field
