### PR TITLE
feature/115-remove-company-field-for-v15

### DIFF
--- a/kefiya/setup/install.py
+++ b/kefiya/setup/install.py
@@ -26,19 +26,10 @@ def get_custom_fields():
 			"fieldname": "kefiya_section",
 			"fieldtype": "Section Break",
 		},
-        {
-            "fieldname": "company",
-            "fieldtype": "Link",
-            "label": "Company",
-            "options": "Company",
-            "print_hide": 1,
-            "remember_last_selected_value": 1,
-            "insert_after": "kefiya_section",
-        },
 		{
 			"fieldname": "kefiya_column_break",
 			"fieldtype": "Column Break",
-			"insert_after": "company",
+			"insert_after": "kefiya_section",
 		},
 		{
 			"label": "Company Bank Account",


### PR DESCRIPTION
- Task: [#115](https://git.phamos.eu/gallehr/kefiya/-/issues/115?show=1546#note_10259)
- Removed the Company field for the v-15 ERPNext version because it already includes its own standard Company field, which was causing a conflict.