### PR TITLE
fix/67-thousand-separator

### DIFF
--- a/kefiya/events/hammer_script/payment_request_on_submit.py
+++ b/kefiya/events/hammer_script/payment_request_on_submit.py
@@ -64,10 +64,10 @@ def export_request(payment_request_name):
         postext += (doc.mode_of_payment or '') + ';'
 
         if doc.payment_request_type == "Outward":
-            postext += str(frappe.format(invoicedoc.grand_total)) + ';'
+            postext += str(frappe.format(invoicedoc.grand_total)).replace('.','') + ';'
         elif doc.payment_request_type == "Inward":
             postext += "-"
-            postext += str(frappe.format(invoicedoc.grand_total)) + ';'
+            postext += str(frappe.format(invoicedoc.grand_total)).replace('.','') + ';'
 
         postext += (doc.currency or '') + '\n'
         buffer.write(postext)


### PR DESCRIPTION
- Task: [#69](https://git.phamos.eu/gallehr/gallehr/-/work_items/69)
- Fixed the thousand separator on moneyplex export of csv file.

Before 

![previous](https://github.com/user-attachments/assets/fdc68195-e2f9-4442-a48b-28b6938b2bc4)


After

![now](https://github.com/user-attachments/assets/65084c6e-cfc8-491b-a7df-0d56e3d3ed97)

