### PR TITLE
feature/70-add-supplier-invoice-number

### DIFF
--- a/kefiya/kefiya/page/bank_transaction_wiz/bank_transaction_row.html
+++ b/kefiya/kefiya/page/bank_transaction_wiz/bank_transaction_row.html
@@ -28,6 +28,8 @@
         {% if matchAgainst == "Purchase Invoice" %}
         <div class="col-sm-2 ellipsis">
           <a href="purchase-invoice/{{ name }}">{{ name }}</a>
+          <br>
+          <p>{{bill_no}}</p>
         </div>
         <div class="col-sm-2 ellipsis hidden-xs">
           {{ supplier }} 

--- a/kefiya/kefiya/page/bank_transaction_wiz/bank_transaction_wiz.js
+++ b/kefiya/kefiya/page/bank_transaction_wiz/bank_transaction_wiz.js
@@ -229,6 +229,7 @@ kefiya.tools.AssignWizardTool = class AssignWizardTool extends (
 				"due_date",
 				"currency",
 				"paid_amount",
+				"bill_no"
 			];
 		} else if (this.kefiyaSettings.assign_against === 'Journal Entry'){
 			this.fields = [


### PR DESCRIPTION
- Task: [#70](https://git.phamos.eu/gallehr/gallehr/-/work_items/70)
- Added a `Supplier Invoice No` value on the purchase invoice tab of bank transaction wizard under the Name column.

![supplier_invoice_number](https://github.com/user-attachments/assets/89416c63-1340-49e9-b24b-7e18c5e533dd)
