### PR TITLE
feature/124-transaction-description-visibility

### DIFF
--- a/kefiya/kefiya/page/bank_account_wizard/bank_account_wizard.js
+++ b/kefiya/kefiya/page/bank_account_wizard/bank_account_wizard.js
@@ -165,8 +165,7 @@ kefiya.tools.bankWizardRow = class BankWizardRow {
 		this.bind_events();
 	}
 
-	make() {		
-		this.data.date = frappe.datetime.str_to_user(this.data.date);
+	make() {
 		this.data.deposit = format_currency(this.data.deposit, this.data.currency);
 		this.data.withdrawal = format_currency(this.data.withdrawal, this.data.currency);
 		$(this.row).append(frappe.render_template("bank_account_wizard_row",

--- a/kefiya/kefiya/page/bank_account_wizard/bank_account_wizard_row.html
+++ b/kefiya/kefiya/page/bank_account_wizard/bank_account_wizard_row.html
@@ -16,9 +16,14 @@
 				<div class="ellipsis">{{ deposit }} / {{withdrawal}}</div>
 			</div>
 		</div>
-		<div class="col-sm-2 ellipsis hidden-xs">
+		<div class="col-sm-2 ellipsis hidden-xs description-container" 
+			style="width: 150px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; cursor: pointer;" 
+			data-toggle="tooltip" 
+			data-placement="top" 
+			title="{{ description }}">
 			{{ description }}
 		</div>
+
 		<div class="col-sm-3 hidden-xs">
 			<div class="clickable-section" data-name={{ name }}>
 				<div class="ellipsis">{{ bank_party_iban }}</div>

--- a/kefiya/public/js/controllers/iban_tools.js
+++ b/kefiya/public/js/controllers/iban_tools.js
@@ -76,7 +76,6 @@ kefiya.iban_tools = {
 				}
 			});
 		}else{
-			
 			data = {
 				valid: false,
 				messages: 'Invalid IBAN',
@@ -89,6 +88,32 @@ kefiya.iban_tools = {
 			// frappe.throw(__("Unsupported IBAN country code: {0}",["<b>"+ibanCountryCode+"</b>"]));
 		}
 	},
+	getPartyName: function(party_type, party) {
+		return new Promise((resolve, reject) => {
+			frappe.call({
+				method: 'frappe.client.get',
+				args: {
+					doctype: party_type,
+					name: party
+				},
+				callback: function(r) {
+					if (r.message) {
+						if (party_type === "Customer"){
+							resolve(r.message.customer_name);
+						}
+						else if (party_type === "Supplier"){
+							resolve(r.message.supplier_name);
+						}
+					} else {
+						reject("No party found");
+					}
+				},
+				error: function(err) {
+					reject(err);
+				}
+			});
+		});
+	},	
 	createPartyBankAccount: function(frm, bankInfo, resultCallback) {
 		frappe.call({
 			method: "kefiya.utils.client.new_bank_account",
@@ -104,13 +129,14 @@ kefiya.iban_tools = {
 		});
 	},
 	setPartyBankAccount: function(frm, callback) {
-		
 		kefiya.iban_tools.getBankDetailsByIBAN(frm.doc.bank_party_iban
-			, function(data) {
+			, async function(data) {
 			
 			if (data.checkResults.bankCode) {
 				
 				let defalutValue = frm.doc.party_type ? frm.doc.party_type:frm.doc.deposit > 0 ? 'Customer': 'Supplier'
+				let party_name = await kefiya.iban_tools.getPartyName(defalutValue, frm.doc.party)
+				
 				let dialog = new frappe.ui.Dialog({
 					title: __('Create Bank Account'),
 					fields: [{
@@ -168,7 +194,18 @@ kefiya.iban_tools = {
 						fieldtype: 'Link',
 						reqd: 1,
 						default: frm.doc.party,
-						options: defalutValue
+						options: defalutValue,
+						onchange: async function(){
+							party_name = await kefiya.iban_tools.getPartyName(dialog.get_value('party_type'), dialog.get_value('party'))
+							dialog.set_value('party_name', party_name);
+							dialog.fields_dict['party'].refresh();
+						}
+					}, {
+						label: 'Party Name',
+						fieldname: 'party_name',
+						fieldtype: 'Data',
+						default: party_name
+						
 					},  {
 						label: 'Description',
 						fieldname: 'description',

--- a/kefiya/public/js/controllers/iban_tools.js
+++ b/kefiya/public/js/controllers/iban_tools.js
@@ -135,7 +135,11 @@ kefiya.iban_tools = {
 			if (data.checkResults.bankCode) {
 				
 				let defalutValue = frm.doc.party_type ? frm.doc.party_type:frm.doc.deposit > 0 ? 'Customer': 'Supplier'
-				let party_name = await kefiya.iban_tools.getPartyName(defalutValue, frm.doc.party)
+
+				let party_name = ""
+				if (defalutValue && frm.doc.party){
+					party_name = await kefiya.iban_tools.getPartyName(defalutValue, frm.doc.party)
+				}
 				
 				let dialog = new frappe.ui.Dialog({
 					title: __('Create Bank Account'),

--- a/kefiya/public/js/controllers/iban_tools.js
+++ b/kefiya/public/js/controllers/iban_tools.js
@@ -157,7 +157,6 @@ kefiya.iban_tools = {
 						label: 'Date',
 						fieldname: 'date',
 						fieldtype: 'Date',
-						read_only: 1,
 						default: frm.doc.date,
 					}, {
 						label: 'Depost',


### PR DESCRIPTION
- Task: [#124](https://git.phamos.eu/gallehr/kefiya/-/work_items/124)
- The full transaction description will be fully displayed when hovering over it

<img width="1296" alt="Screenshot 2025-02-06 at 2 10 18 in the afternoon" src="https://github.com/user-attachments/assets/93f913ac-2c87-482c-8394-629604094fc7" />

- Task: [#123](https://git.phamos.eu/gallehr/kefiya/-/issues/117?show=2212)
- Added a party name field on the bank account wizard dialog

![Screenshot from 2025-02-06 18-58-33](https://github.com/user-attachments/assets/7cd1bc15-c5d2-41ce-8c56-b56274098949)

- Task: [#121](https://git.phamos.eu/gallehr/kefiya/-/work_items/121)
- Fixed the incorrect date conversion
- Made the date editable field

![Screenshot 2025-02-07 at 10 06 20 in the morning – ScreenClip](https://github.com/user-attachments/assets/7e024229-7b9b-458f-907a-b6388b0a3c23)

