### PR TITLE
fix/128-bank-transaction-wizard-display

### DIFF
--- a/kefiya/kefiya/page/bank_transaction_wiz/bank_transaction_row.html
+++ b/kefiya/kefiya/page/bank_transaction_wiz/bank_transaction_row.html
@@ -1,6 +1,6 @@
 <!-- Sales Invoice or Purchase Invoice -->
 {% if matchAgainst == "Sales Invoice" || matchAgainst == "Purchase Invoice" %}
-<div class="list-row payment-assign-wizard-item list-xs-height mb-4" data-fieldname="{{ name }}">
+<div class="list-row payment-assign-wizard-item list-xs-height" data-fieldname="{{ name }}" style="height: auto;">
     <div class="clickable-section" data-name="{{ name }}">
       <div class="row">
         <div class="col-sm-2 hidden-xs" style="padding-right: 0px">


### PR DESCRIPTION
- Task: [#128](https://git.phamos.eu/gallehr/kefiya/-/issues/128?show=2445)
- Fixed the text overlap on Bank Transaction Wizard UI.

Before

<img width="1291" alt="before" src="https://github.com/user-attachments/assets/4f6b2ca4-00e5-4e5c-906b-aa856c7fe371" />

After

<img width="1282" alt="after" src="https://github.com/user-attachments/assets/e1c4fc06-fc74-4984-b608-2cc3e578490d" />
