### PR TITLE
fix/127-unreconcile-transaction

### DIFF
--- a/kefiya/hooks.py
+++ b/kefiya/hooks.py
@@ -94,7 +94,8 @@ before_install = "kefiya.utils.install.before_install"
 # Override standard doctype classes
 
 override_doctype_class = {
-    "Journal Entry": "kefiya.overrides.journal_entry.journal_entry.CustomJournalEntry"
+    "Journal Entry": "kefiya.overrides.journal_entry.journal_entry.CustomJournalEntry",
+    "Bank Transaction": "kefiya.overrides.bank_transaction.bank_transaction.CustomBankTransaction",
 }
 
 # Document Events

--- a/kefiya/kefiya/doctype/kefiya_settings/kefiya_settings.json
+++ b/kefiya/kefiya/doctype/kefiya_settings/kefiya_settings.json
@@ -10,6 +10,7 @@
   "show_entries_in_payment_assignment_wizard",
   "overlap_days",
   "column_break_gv35w",
+  "cancel_payment_entries_on_unreconciliation",
   "column_break_qzdrd",
   "payment_request_csv_action",
   "recipient_email"
@@ -65,14 +66,20 @@
    "fieldname": "overlap_days",
    "fieldtype": "Int",
    "label": "Overlap Days",
-   "length": 0,
    "non_negative": 1
+  },
+  {
+   "default": "0",
+   "description": "Enable this option to automatically cancel any payment entries associated with a bank transaction when the transaction is unreconciled.",
+   "fieldname": "cancel_payment_entries_on_unreconciliation",
+   "fieldtype": "Check",
+   "label": "Cancel Payment Entries on Unreconciliation"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-02-10 14:09:32.312151",
+ "modified": "2025-02-28 14:39:41.487314",
  "modified_by": "Administrator",
  "module": "Kefiya",
  "name": "Kefiya Settings",

--- a/kefiya/overrides/bank_transaction/bank_transaction.py
+++ b/kefiya/overrides/bank_transaction/bank_transaction.py
@@ -1,0 +1,26 @@
+import frappe
+from erpnext.accounts.doctype.bank_transaction.bank_transaction import BankTransaction
+
+class CustomBankTransaction(BankTransaction):
+    @frappe.whitelist()
+    def remove_payment_entries(self):
+        payment_entries = []
+        for payment_entry in self.payment_entries[:]:
+            self.remove_payment_entry(payment_entry)
+            payment_entries.append(payment_entry)
+
+        # runs on_update_after_submit
+        self.save()
+        
+        should_cancel = self.cancel_entries_on_unreconciling()
+        for payment_entry in payment_entries:
+            if should_cancel and payment_entry.payment_document == "Payment Entry":
+                self.cancel_payment_entry(payment_entry)
+
+    def cancel_entries_on_unreconciling(self):
+        settings = frappe.get_single("Kefiya Settings")
+        return settings.cancel_payment_entries_on_unreconciliation
+    
+    def cancel_payment_entry(self, payment_entry):
+        payment_entry = frappe.get_doc("Payment Entry", payment_entry.payment_entry)
+        payment_entry.cancel()


### PR DESCRIPTION
- Resolves [#129](https://git.phamos.eu/gallehr/kefiya/-/issues/127?show=2444)

1. **Fixed Incomplete Removal of Payment Entries:**
**Issue**: Previously, when clicking the "Unreconcile Transaction" button, some payment entries remained in the Bank Transaction’s payment_entries child table due to an unsafe loop that skipped entries during iteration.
**Fix**: Updated the remove_payment_entries method to use a safe copy of self.payment_entries (via self.payment_entries[:]). This ensures all payment entries are processed and removed from the child table, regardless of list modifications mid-loop.

2. **Cancel Payment Entries to Update Invoice Status:**
**New Field**: Added an option to cancel payment entries after unreconciling bank transaction
![kefiay_settings](https://github.com/user-attachments/assets/2d6a144a-296f-450b-99fd-6a27ba998d67)

**Enhancement**: After removing payment entries, the associated Payment Entry records are now canceled (by clearing their clearance_date and triggering appropriate status updates). This ensures linked invoices revert to an "Unpaid" state when applicable.

![test](https://github.com/user-attachments/assets/384e285d-2269-45ca-8f32-45d8a9d4c46f)
