### PR TITLE
feature/138-auto-fill-assigned-amount-in-payment-entries

### DIFF
--- a/kefiya/hooks.py
+++ b/kefiya/hooks.py
@@ -37,7 +37,8 @@ app_license = "MIT"
 
 # include js in doctype views
 doctype_js = {
-	"Payment Request": "public/js/payment_request.js"
+	"Payment Request": "public/js/payment_request.js",
+    "Bank Transaction": "public/js/bank_transaction.js"
 }
 # doctype_js = {"doctype" : "public/js/doctype.js"}
 # doctype_list_js = {"doctype" : "public/js/doctype_list.js"}

--- a/kefiya/overrides/bank_transaction/bank_transaction.py
+++ b/kefiya/overrides/bank_transaction/bank_transaction.py
@@ -8,14 +8,14 @@ class CustomBankTransaction(BankTransaction):
         for payment_entry in self.payment_entries[:]:
             self.remove_payment_entry(payment_entry)
             payment_entries.append(payment_entry)
-
         # runs on_update_after_submit
         self.save()
         
         should_cancel = self.cancel_entries_on_unreconciling()
-        for payment_entry in payment_entries:
-            if should_cancel and payment_entry.payment_document == "Payment Entry":
-                self.cancel_payment_entry(payment_entry)
+        if should_cancel:
+            for payment_entry in payment_entries:
+                if payment_entry.payment_document == "Payment Entry":
+                    self.cancel_payment_entry(payment_entry)
 
     def cancel_entries_on_unreconciling(self):
         settings = frappe.get_single("Kefiya Settings")

--- a/kefiya/public/js/bank_transaction.js
+++ b/kefiya/public/js/bank_transaction.js
@@ -1,0 +1,22 @@
+frappe.ui.form.on("Bank Transaction Payments", {
+    payment_entry: function(frm, cdt, cdn){
+        let row = locals[cdt][cdn];
+        frappe.db.get_doc(row.payment_document, row.payment_entry)
+                .then(payment_entry => {
+                    let allocated_amount = 0
+                    if (row.payment_document == "Payment Entry"){
+                        allocated_amount = payment_entry.total_allocated_amount
+                    } else if (row.payment_document == "Journal Entry"){
+                        allocated_amount = payment_entry.total_debit
+                    } else if (row.payment_document == "Sales Invoice"){
+                        allocated_amount = payment_entry.outstanding_amount
+                    } else if (row.payment_document == "Purchase Invoice"){
+                        allocated_amount = payment_entry.outstanding_amount
+                    } else if (row.payment_document == "Expense Claim"){
+                        allocated_amount = payment_entry.grand_total
+                    }
+                    
+                    frappe.model.set_value(cdt, cdn, "allocated_amount", allocated_amount);
+                })
+    }
+});


### PR DESCRIPTION
- Task: [#138](https://git.phamos.eu/gallehr/kefiya/-/work_items/138)
- The `Allocated Amount` field in Bank Transaction Payments(Bank Transaction child table) is automatically populated based on the selected Payment Document and Payment Entry, eliminating the need for manual entry.
**Mapping**
- Payment Entry → total_allocated_amount
- Journal Entry → total_debit
- Sales Invoice → outstanding_amount
- Purchase Invoice → outstanding_amount
- Expense Claim → grand_total

![Mapping](https://github.com/user-attachments/assets/b3d8d2f0-2a3c-4883-b4c2-40676cdd1493)
