### PR TITLE
fix/bank-transaction-wizard-ui

### DIFF
--- a/kefiya/kefiya/page/bank_transaction_wiz/bank_transaction_row.html
+++ b/kefiya/kefiya/page/bank_transaction_wiz/bank_transaction_row.html
@@ -69,6 +69,8 @@
 
     <div class="col-sm-2 ellipsis hidden-xs">
       {{ party }}
+      <br>
+      {{bank_party_name}}
     </div>
     <div class="col-sm-2 ellipsis">
       {{ unallocated_amount }}

--- a/kefiya/kefiya/page/bank_transaction_wiz/bank_transaction_wiz.js
+++ b/kefiya/kefiya/page/bank_transaction_wiz/bank_transaction_wiz.js
@@ -212,6 +212,7 @@ kefiya.tools.AssignWizardTool = class AssignWizardTool extends (
 				"description",
 				"party",
 				"party_type",
+				"bank_party_name",
 				"unallocated_amount",
 				"deposit",
 				"withdrawal",
@@ -219,7 +220,6 @@ kefiya.tools.AssignWizardTool = class AssignWizardTool extends (
 				"company",
 				"currency",
 				"bank_account",
-				"bank_party_name",
 			];
 		}
 	}


### PR DESCRIPTION
- Task: [#134](https://git.phamos.eu/gallehr/kefiya/-/work_items/134)
- Since the Bank Transaction document does not have a party_name field, it's necessary to fetch the party name from the respective doctype using Party Type and Party. However, retrieving this information for all records while listing them on the Bank Transaction Wizard page could slow down the system. To mitigate this, `Party Name/Account Holder (Bank Statement)`, which comes from the bank, is used. However, this value might differ slightly from the party name stored in the ERP system.

![1](https://github.com/user-attachments/assets/722e8905-1e7c-4ff1-885a-7551d618d8de)
![2](https://github.com/user-attachments/assets/5813f9ed-95a8-4cbd-acd5-f757981f41be)
