### PR TITLE
fix/bank-transaction-wizard

### DIFF
--- a/kefiya/kefiya/page/bank_transaction_wiz/bank_transaction_wiz.css
+++ b/kefiya/kefiya/page/bank_transaction_wiz/bank_transaction_wiz.css
@@ -12,3 +12,37 @@
 .list-row-contain:nth-of-type(even) {
     background-color: #FFFFFF;
 }
+
+/* Hide the Refresh button */
+.icon-btn {
+    display: none !important;
+}
+
+[data-original-title="Refresh"] {
+    display: none !important;
+}
+
+[data-original-title="Reload List"] {
+    display: none !important;
+}
+
+/* Hide the Button group */
+.custom-btn-group {
+    display: none !important;
+}
+
+[data-fieldname="name"] {
+    display: none !important;
+}
+
+[data-fieldname="status"] {
+    display: none !important;
+}
+
+[data-fieldname="bank_account"] {
+    display: none !important;
+}
+
+[data-fieldname="company"] {
+    display: none !important;
+}

--- a/kefiya/kefiya/page/bank_transaction_wiz/bank_transaction_wiz.js
+++ b/kefiya/kefiya/page/bank_transaction_wiz/bank_transaction_wiz.js
@@ -362,7 +362,7 @@ kefiya.tools.AssignWizardTool = class AssignWizardTool extends (
 		$('[data-original-title="Reload List"]').remove();
 		$('[data-fieldname="bank_account"]').remove();
 		$('.custom-btn-group').remove();
-		$('.standard-filter-section').empty();	
+		$('.standard-filter-section').empty();
 		const tab_container = await this.add_custom();
 		tab_container.appendTo('.standard-filter-section');
 		
@@ -576,7 +576,7 @@ kefiya.tools.AssignWizardRow = class AssignWizardRow {
 					fieldtype: 'Small Text',
 					read_only:  me.data.description ? 1 : 0,
 					reqd: 1,
-					default: me.data.description.substring(0, 140),
+					default: me.data.description ? me.data.description.substring(0, 140) : '',
 				}, {
 					label: 'Posting Date',
 					fieldname: 'posting_date',

--- a/kefiya/overrides/bank_reconciliation_tool/bank_reconciliation_tool.py
+++ b/kefiya/overrides/bank_reconciliation_tool/bank_reconciliation_tool.py
@@ -89,6 +89,8 @@ def custom_create_journal_entry_bts(
     # convert transaction amount to company currency
     if is_multi_currency:
         exc_rate = get_exchange_rate(bank_transaction.currency, company_default_currency, posting_date)
+        if not exc_rate:
+            frappe.throw('Set the transaction exchange rate.')
         withdrawal_in_company_currency = flt(exc_rate * abs(bank_transaction.withdrawal))
         deposit_in_company_currency = flt(exc_rate * abs(bank_transaction.deposit))
     else:


### PR DESCRIPTION
- Task: [#136](https://git.phamos.eu/gallehr/kefiya/-/work_items/136)
- Hide the multiple loading indicator that appear on bank transaction wizard
- Solved the flickering issue while displaying the records

![Bank Transaction Wizard](https://github.com/user-attachments/assets/da670e5d-8aa7-454e-95bb-82615c12e293)
