### PR TITLE
feat/50-feedback-v15

### DIFF
--- a/kefiya/kefiya/doctype/kefiya_settings/kefiya_settings.json
+++ b/kefiya/kefiya/doctype/kefiya_settings/kefiya_settings.json
@@ -10,7 +10,7 @@
   "show_entries_in_payment_assignment_wizard",
   "overlap_days",
   "column_break_gv35w",
-  "cancel_payment_entries_on_unreconciliation",
+  "delete_payment_entries_on_unreconciliation",
   "column_break_qzdrd",
   "payment_request_csv_action",
   "recipient_email"
@@ -70,16 +70,16 @@
   },
   {
    "default": "0",
-   "description": "Enable this option to automatically cancel any payment entries associated with a bank transaction when the transaction is unreconciled.",
-   "fieldname": "cancel_payment_entries_on_unreconciliation",
+   "description": "Enable this option to automatically delete any payment entries associated with a bank transaction when the transaction is unreconciled.",
+   "fieldname": "delete_payment_entries_on_unreconciliation",
    "fieldtype": "Check",
-   "label": "Cancel Payment Entries on Unreconciliation"
+   "label": "Delete Payment Entries on Unreconciliation"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-05-20 10:28:36.688168",
+ "modified": "2025-06-25 14:46:37.259217",
  "modified_by": "Administrator",
  "module": "Kefiya",
  "name": "Kefiya Settings",

--- a/kefiya/kefiya/page/bank_transaction_wiz/bank_transaction_header.html
+++ b/kefiya/kefiya/page/bank_transaction_wiz/bank_transaction_header.html
@@ -9,11 +9,10 @@
   <div class="level list-row list-row-head text-muted small">
     <div class="col-sm-2 ellipsis">{{ __("Action") }}</div>
     <div class="col-sm-2 ellipsis">{{ __("Name") }}</div>
-    <div class="col-sm-2 ellipsis hidden-xs">{{ __("Party") }}</div>
+    <div class="col-sm-2 ellipsis hidden-xs">{{ party_label }}</div>
     <div class="col-sm-2 ellipsis hidden-xs">
       {{ __("Outstanding Amount") }}
     </div>
-    <!-- <div class="col-sm-2 ellipsis hidden-xs">{{ __("Posting Date") }}</div> -->
     <div class="col-sm-2 ellipsis list-subject hidden-xs">
       {{ __("Posting Date") }}
     </div>

--- a/kefiya/kefiya/page/bank_transaction_wiz/bank_transaction_wiz.css
+++ b/kefiya/kefiya/page/bank_transaction_wiz/bank_transaction_wiz.css
@@ -1,48 +1,48 @@
-.list-row-contain {
+.bank-transaction-wiz-page .list-row-contain {
     border: 1px solid #ccc;
     border-radius: 5px;
     margin-bottom: 10px;
     padding: 10px;
 }
 
-.list-row-contain:nth-of-type(odd) {
+.bank-transaction-wiz-page .list-row-contain:nth-of-type(odd) {
     background-color: #F3F3F3;
 }
 
-.list-row-contain:nth-of-type(even) {
+.bank-transaction-wiz-page .list-row-contain:nth-of-type(even) {
     background-color: #FFFFFF;
 }
 
 /* Hide the Refresh button */
-.icon-btn {
+.bank-transaction-wiz-page .icon-btn {
     display: none !important;
 }
 
-[data-original-title="Refresh"] {
+.bank-transaction-wiz-page [data-original-title="Refresh"] {
     display: none !important;
 }
 
-[data-original-title="Reload List"] {
+.bank-transaction-wiz-page [data-original-title="Reload List"] {
     display: none !important;
 }
 
 /* Hide the Button group */
-.custom-btn-group {
+.bank-transaction-wiz-page .custom-btn-group {
     display: none !important;
 }
 
-[data-fieldname="name"] {
+.bank-transaction-wiz-page [data-fieldname="name"] {
     display: none !important;
 }
 
-[data-fieldname="status"] {
+.bank-transaction-wiz-page [data-fieldname="status"] {
     display: none !important;
 }
 
-[data-fieldname="bank_account"] {
+.bank-transaction-wiz-page [data-fieldname="bank_account"] {
     display: none !important;
 }
 
-[data-fieldname="company"] {
+.bank-transaction-wiz-page [data-fieldname="company"] {
     display: none !important;
 }

--- a/kefiya/kefiya/page/bank_transaction_wiz/bank_transaction_wiz.js
+++ b/kefiya/kefiya/page/bank_transaction_wiz/bank_transaction_wiz.js
@@ -253,7 +253,7 @@ kefiya.tools.AssignWizardTool = class AssignWizardTool extends (
 	}
 
 	setup_view() {
-		this.render_header();
+		this.render_header(this.kefiyaSettings.assign_against);
 	}
 
 	setup_side_bar() {
@@ -450,10 +450,16 @@ kefiya.tools.AssignWizardTool = class AssignWizardTool extends (
 		}
 	}
 
-	render_header() {
+	render_header(assignAgainst) {
 		const me = this;
 		if ($(this.wrapper).find(".payment-assign-wizard-header").length === 0) {
-			me.$result.append(frappe.render_template("bank_transaction_header"));
+			me.$result.append(frappe.render_template("bank_transaction_header", {
+				party_label: assignAgainst === "Sales Invoice"
+				? __("Customer")
+				: assignAgainst === "Purchase Invoice" || assignAgainst === "Refund"
+					? __("Supplier")
+					: __("Party")
+			}));
 		}
 	}
 };

--- a/kefiya/kefiya/page/bank_transaction_wiz/bank_transaction_wiz.js
+++ b/kefiya/kefiya/page/bank_transaction_wiz/bank_transaction_wiz.js
@@ -18,10 +18,11 @@ kefiya.tools.assignWizard = class assignWizard {
 		this.parent = wrapper;
 		this.page = this.parent.page;
 		this.remove_page_buttons();
+		$(this.page.wrapper).addClass('bank-transaction-wiz-page');
 		this.make();
 	}
 	remove_page_buttons(){
-		$('.menu-btn-group').remove()
+		$(this.page.wrapper).find('.menu-btn-group').remove();
 	}
 
 	async fetchKefiyaSettings() {
@@ -393,18 +394,18 @@ kefiya.tools.AssignWizardTool = class AssignWizardTool extends (
 
 		const me = this;
 		this.$result.find(".list-row-contain").remove();
-		$('[data-fieldname="name"]').remove();
-		$('[data-fieldname="status"]').remove();
-		$('[data-fieldname="title"]').remove();
-		$('[data-original-title="Refresh"]').remove();
-		$('[data-original-title="Reload List"]').remove();
-		$('[data-fieldname="bank_account"]').remove();
-		$('.custom-btn-group').remove();
-		$('.standard-filter-section').empty();
+		$(this.page.wrapper).find('[data-fieldname="name"]').remove();
+		$(this.page.wrapper).find('[data-fieldname="status"]').remove();
+		$(this.page.wrapper).find('[data-fieldname="title"]').remove();
+		$(this.page.wrapper).find('[data-original-title="Refresh"]').remove();
+		$(this.page.wrapper).find('[data-original-title="Refresh"]').remove();
+		$(this.page.wrapper).find('[data-original-title="Reload List"]').remove();
+		$(this.page.wrapper).find('[data-fieldname="bank_account"]').remove();
+		$(this.page.wrapper).find('.custom-btn-group').remove();
+		$(this.page.wrapper).find('.standard-filter-section').empty();
 		const tab_container = await this.add_custom();
 		tab_container.appendTo('.standard-filter-section');
-		
-		
+
 		let rowHTML;
 		let party_value;
 		rowHTML = '<div class="list-row-contain"></div>';

--- a/kefiya/overrides/bank_transaction/bank_transaction.py
+++ b/kefiya/overrides/bank_transaction/bank_transaction.py
@@ -11,16 +11,17 @@ class CustomBankTransaction(BankTransaction):
         # runs on_update_after_submit
         self.save()
         
-        should_cancel = self.cancel_entries_on_unreconciling()
-        if should_cancel:
+        should_delete = self.delete_entries_on_unreconciling()
+        if should_delete:
             for payment_entry in payment_entries:
                 if payment_entry.payment_document == "Payment Entry":
-                    self.cancel_payment_entry(payment_entry)
+                    self.delete_payment_entry(payment_entry)
 
-    def cancel_entries_on_unreconciling(self):
+    def delete_entries_on_unreconciling(self):
         settings = frappe.get_single("Kefiya Settings")
-        return settings.cancel_payment_entries_on_unreconciliation
+        return settings.delete_payment_entries_on_unreconciliation
     
-    def cancel_payment_entry(self, payment_entry):
+    def delete_payment_entry(self, payment_entry):
         payment_entry = frappe.get_doc("Payment Entry", payment_entry.payment_entry)
         payment_entry.cancel()
+        payment_entry.delete()


### PR DESCRIPTION
## Description

* This PR introduces improvements to the Bank Transaction Wizard page and related functionalities for better usability and consistency.

**Key changes:**

* Fixed issue where standard filters and buttons (e.g., Unreconcile) were missing when navigating from the Bank Transaction Wizard page to other doctypes in v15 by properly cleaning up custom DOM elements.
* Standardized the "Party" column label and filter behavior across documents: dynamically changed the header to "Customer" for Sales Invoices, "Supplier" for Purchase Invoices and Refunds, and kept it as "Party" for Journal Entries since bank transactions can relate to both suppliers and customers.
* Added a checkbox on Kefiya Settings that allow deletion of payment entries during unreconciliation of transactions

**Related issue(s)/ticket(s):**

* [GitLab Parent Issue](https://git.phamos.eu/gallehr/kefiya/-/issues/150)

**Testing done:**

* Manual testing conducted for all implemented changes.

**Checklist:**

* [x] I followed this [[guideline](https://doku.phamos.eu/books/developer-onboarding/page/pull-request-creation)](https://doku.phamos.eu/books/developer-onboarding/page/pull-request-creation)
* [x] I created feature branch from develop
* [x] The name of the feature branch follows conventions
* [x] I created logical commit with clear messages
* [x] I pulled the changes from develop (again) and resolved possible conflicts
* [x] I pushed changes to remote feature branch
* [x] I created a Pull Request with title and description as described in the guideline
* [x] I checked if there is any conflict after creating the PR