### PR TITLE
feat/150-enable-matching-of-credit-amounts-in-bank-transactions

### DIFF
--- a/kefiya/kefiya/page/bank_transaction_wiz/bank_transaction_row.html
+++ b/kefiya/kefiya/page/bank_transaction_wiz/bank_transaction_row.html
@@ -139,15 +139,7 @@
             {{ payment.bank_party_name }}
           </div>
           <div class="col-sm-2 ellipsis data-amount">
-            {% if matchAgainst == "Refund" %}
-              {% if payment.deposit > payment.withdrawal %}
-                + {{ payment.unallocated_amount }}
-              {% else %}
-                - {{ payment.unallocated_amount }}
-              {% endif %}
-            {% else %}
               {{ payment.unallocated_amount }}
-            {% endif %}
           </div>
           <div class="col-sm-2 ellipsis">
             {{ payment.date }}

--- a/kefiya/kefiya/page/bank_transaction_wiz/bank_transaction_wiz.js
+++ b/kefiya/kefiya/page/bank_transaction_wiz/bank_transaction_wiz.js
@@ -547,58 +547,70 @@ kefiya.tools.AssignWizardRow = class AssignWizardRow {
 				callback: function (r) {
 					let vouchers = [];
 
-					const paid_amount = r.message[0];
-					const payment_entry_name = r.message[1];
-					const unallocated_amount = r.message[2];
-					const outstanding_amount = r.message[3];
-					const diff = r.message[4];
+					if (match_against == "Refund"){
 
-					vouchers.push({
-						payment_doctype: "Payment Entry",
-						payment_name: payment_entry_name,
-						amount: format_currency(paid_amount, currency),
-					});
-					
-					frappe.call({
-						method:
-							"erpnext.accounts.doctype.bank_reconciliation_tool.bank_reconciliation_tool.reconcile_vouchers",
-						args: {
-							bank_transaction_name: bank_transaction_name,
-							vouchers: vouchers,
-						},
-						callback(/* r */) {
-							// Refresh page after asignment		
-							// kefiya.tools.assignWizardList.refresh();
+						const unallocated_amount = r.message[0];
 
-							if (unallocated_amount > outstanding_amount){
+						$('.list-row-contain').filter(function() {
+							return $(this).find(`[data-fieldname="${invoice_name}"]`).length > 0;
+						}).remove();
+
+						$(`[data-fieldname="${bank_transaction_name}"]`).each(function() {
+							$(this).find('.data-amount').text(unallocated_amount);
+						});
+
+					} else {
+						const paid_amount = r.message[0];
+						const payment_entry_name = r.message[1];
+						const unallocated_amount = r.message[2];
+						const outstanding_amount = r.message[3];
+						const diff = r.message[4];
+
+						vouchers.push({
+							payment_doctype: "Payment Entry",
+							payment_name: payment_entry_name,
+							amount: format_currency(paid_amount, currency),
+						});
+						
+						frappe.call({
+							method:
+								"erpnext.accounts.doctype.bank_reconciliation_tool.bank_reconciliation_tool.reconcile_vouchers",
+							args: {
+								bank_transaction_name: bank_transaction_name,
+								vouchers: vouchers,
+							},
+							callback(/* r */) {
+								// Refresh page after asignment		
+								// kefiya.tools.assignWizardList.refresh();
+
+								if (unallocated_amount > outstanding_amount){
+
+									$('.list-row-contain').filter(function() {
+										return $(this).find(`[data-fieldname="${invoice_name}"]`).length > 0;
+									}).remove();
+
+									$(`[data-fieldname="${bank_transaction_name}"]`).each(function() {
+										$(this).find('.data-amount').text(diff);
+									});
+								}else if(unallocated_amount == outstanding_amount){
+
+									$('.list-row-contain').filter(function() {
+										return $(this).find(`[data-fieldname="${invoice_name}"]`).length > 0;
+									}).remove();
+
+									$(`[data-fieldname="${bank_transaction_name}"]`).remove();
+								}else{
+									
+									$(`[data-fieldname="${bank_transaction_name}"]`).remove();
+									$(`[data-fieldname="${invoice_name}"]`).find('.data-amount').text(diff);
+								}
 
 								$('.list-row-contain').filter(function() {
-									return $(this).find(`[data-fieldname="${invoice_name}"]`).length > 0;
+									return $(this).children().length === 1;
 								}).remove();
-
-								$(`[data-fieldname="${bank_transaction_name}"]`).each(function() {
-									$(this).find('.data-amount').text(diff);
-								});
-							}else if(unallocated_amount == outstanding_amount){
-
-								$('.list-row-contain').filter(function() {
-									return $(this).find(`[data-fieldname="${invoice_name}"]`).length > 0;
-								}).remove();
-
-								$(`[data-fieldname="${bank_transaction_name}"]`).remove();
-							}else{
-								
-								$(`[data-fieldname="${bank_transaction_name}"]`).remove();
-								$(`[data-fieldname="${invoice_name}"]`).find('.data-amount').text(diff);
-							}
-
-							$('.list-row-contain').filter(function() {
-								return $(this).children().length === 1;
-							}).remove();
-							
-
-						},
-					});
+							},
+						});
+					}
 				},
 			});
 

--- a/kefiya/kefiya/page/bank_transaction_wiz/bank_transaction_wiz.js
+++ b/kefiya/kefiya/page/bank_transaction_wiz/bank_transaction_wiz.js
@@ -549,7 +549,7 @@ kefiya.tools.AssignWizardRow = class AssignWizardRow {
 
 					if (match_against == "Refund"){
 
-						const unallocated_amount = r.message[0];
+						const unallocated_amount = r.message;
 
 						$('.list-row-contain').filter(function() {
 							return $(this).find(`[data-fieldname="${invoice_name}"]`).length > 0;

--- a/kefiya/overrides/bank_transaction/bank_transaction.py
+++ b/kefiya/overrides/bank_transaction/bank_transaction.py
@@ -16,6 +16,8 @@ class CustomBankTransaction(BankTransaction):
             for payment_entry in payment_entries:
                 if payment_entry.payment_document == "Payment Entry":
                     self.delete_payment_entry(payment_entry)
+                elif payment_entry.payment_document == "Journal Entry":
+                    self.delete_journal_entry(payment_entry)
 
     def delete_entries_on_unreconciling(self):
         settings = frappe.get_single("Kefiya Settings")
@@ -25,3 +27,8 @@ class CustomBankTransaction(BankTransaction):
         payment_entry = frappe.get_doc("Payment Entry", payment_entry.payment_entry)
         payment_entry.cancel()
         payment_entry.delete()
+    
+    def delete_journal_entry(self, payment_entry):
+        journal_entry = frappe.get_doc("Journal Entry", payment_entry.payment_entry)
+        journal_entry.cancel()
+        journal_entry.delete()

--- a/kefiya/utils/client.py
+++ b/kefiya/utils/client.py
@@ -4,7 +4,6 @@
 from __future__ import unicode_literals
 
 import frappe
-from frappe.utils import getdate
 from frappe.utils import today
 
 @frappe.whitelist()
@@ -125,6 +124,45 @@ def auto_assign_payments():
     return AssignmentController().auto_assign_payments()
 
 
+def create_refund_journal_entry_from_purchase_invoice(invoice_doc, bank_transaction_name, refund_account):
+    """Create a journal entry for refunding a purchase invoice."""
+
+    je = frappe.new_doc("Journal Entry")
+    je.posting_date = today()
+    je.company = invoice_doc.company
+    je.voucher_type = "Journal Entry"
+    je.user_remark = f"Refund for Return Invoice {invoice_doc.name}"
+    
+    je.append("accounts", {
+        "account": refund_account,
+        "debit_in_account_currency": abs(invoice_doc.outstanding_amount),
+        "credit_in_account_currency": 0,
+    })
+
+    je.append("accounts", {
+        "account": invoice_doc.credit_to,
+        "party_type": "Supplier",
+        "party": invoice_doc.supplier,
+        "credit_in_account_currency": abs(invoice_doc.outstanding_amount),
+        "debit_in_account_currency": 0,
+        "reference_type": "Purchase Invoice",
+        "reference_name": invoice_doc.name
+    })
+
+    je.insert()
+    je.submit()
+
+    bt = frappe.get_doc("Bank Transaction", bank_transaction_name)
+    
+    bt.append("payment_entries", {
+        "payment_document": "Journal Entry",
+        "payment_entry": je.name,
+        "allocated_amount": -abs(invoice_doc.outstanding_amount)  # NEGATIVE to increase unallocated
+    })
+    bt.save()
+
+    return frappe.format(abs(bt.unallocated_amount), "Currency")
+
 
 # Create Payment Entry record when reconcile button is clicked
 @frappe.whitelist()
@@ -132,49 +170,18 @@ def create_payment_entry(bank_transaction_name, invoice_name, match_against):
     """Create payment entry document from sales or purchase invoice doctype.
     """
     if match_against == "Refund":
-        match_against = "Purchase Invoice"
+        invoice_doc = frappe.get_doc("Purchase Invoice", invoice_name)
         bank_transaction = frappe.get_doc("Bank Transaction", bank_transaction_name)
-        invoice_doc = frappe.get_doc(match_against, invoice_name)
-
-        unallocated_amount = bank_transaction.unallocated_amount
-        outstanding_amount = invoice_doc.outstanding_amount
-
-        diff = frappe.format((unallocated_amount - abs(outstanding_amount)), "Currency")
-        paid_amount = outstanding_amount
-        if unallocated_amount <= abs(outstanding_amount):
-            paid_amount = 0 - unallocated_amount
-
-        payment_entry = frappe.call("erpnext.accounts.doctype.payment_entry.payment_entry.get_payment_entry", match_against, invoice_name)
-        payment_entry.paid_amount = abs(paid_amount)
-        payment_entry.reference_date = today()
-        payment_entry.reference_no = 'BTN Wizard '+ today()
-        payment_entry.payment_type = "Receive"
-        account_from_to = "paid_to"
-
         bank_account = ''
         if bank_transaction.bank_account:
             bank_account = frappe.db.get_values(
                 "Bank Account", bank_transaction.bank_account, ["account", "company"], as_dict=True
             )[0]
-
-        if bank_account and bank_account.account:
-            (gl_account, company) = (bank_account.account, bank_account.company)
-
-            payment_entry.bank_account = bank_transaction.bank_account
-
-            if account_from_to == "paid_to":
-                payment_entry.paid_to = gl_account
+        if bank_account:
+            if bank_account.account:
+                return create_refund_journal_entry_from_purchase_invoice(invoice_doc, bank_transaction_name, bank_account.account)
             else:
-                payment_entry.paid_from = gl_account
-
-
-        for reference in payment_entry.references:
-            reference.allocated_amount = paid_amount
-
-        payment_entry.insert()
-        payment_entry.submit()
-
-        return abs(paid_amount), payment_entry.name, unallocated_amount, abs(outstanding_amount), diff
+                frappe.throw("Bank Account {} has no account set.".format(bank_transaction.bank_account))
     else:
         bank_transaction = frappe.get_doc("Bank Transaction", bank_transaction_name)
         invoice_doc = frappe.get_doc(match_against, invoice_name)
@@ -210,7 +217,6 @@ def create_payment_entry(bank_transaction_name, invoice_name, match_against):
                 payment_entry.paid_to = gl_account
             else:
                 payment_entry.paid_from = gl_account
-
 
         for reference in payment_entry.references:
             reference.allocated_amount = paid_amount


### PR DESCRIPTION
## Description

* This PR introduces improvements to the Bank Transaction Wizard.

**Key changes:**

* Included a Refund tab to reconcile a Mastercard transactions posted as a single bank withdrawal/deposits containing both expenses and a refund
* Inserted the created journal entry from the return purchase invoice into the respective bank transaction’s payment entries child table with a negative allocated amount to correctly increase the unallocated amount.
* Removed the respective Purchase Invoice row from the UI without refreshing the page.
* Implemented logic to cancel and remove the associated Journal Entry when a Bank Transaction is unreconciled and the entry exists in the Payment Entry child table.

**Related issue(s)/ticket(s):**

* [GitLab Parent Issue](https://git.phamos.eu/gallehr/kefiya/-/issues/150)
* [GitLab Child Issue](https://git.phamos.eu/gallehr/kefiya/-/issues/150?show=3949)

**GIF:**

![mastercard-reconciliation](https://github.com/user-attachments/assets/c108040e-7a23-4a27-a96b-dbdbbf9f0ac5)


**Testing done:**

* Manual testing conducted for all implemented changes.

**Checklist:**

* [x] I followed this [[guideline](https://doku.phamos.eu/books/developer-onboarding/page/pull-request-creation)](https://doku.phamos.eu/books/developer-onboarding/page/pull-request-creation)
* [x] I created feature branch from develop
* [x] The name of the feature branch follows conventions
* [x] I created logical commit with clear messages
* [x] I pulled the changes from develop (again) and resolved possible conflicts
* [x] I pushed changes to remote feature branch
* [x] I created a Pull Request with title and description as described in the guideline
* [x] I checked if there is any conflict after creating the PR