### PR TITLE
fix/165-multiple-mastercards-selection

### DIFF
--- a/kefiya/kefiya/doctype/kefiya_settings/kefiya_settings.json
+++ b/kefiya/kefiya/doctype/kefiya_settings/kefiya_settings.json
@@ -81,9 +81,9 @@
   {
    "description": "Supplier associated with the Mastercard transactions",
    "fieldname": "mastercard",
-   "fieldtype": "Link",
+   "fieldtype": "Table MultiSelect",
    "label": "Mastercard",
-   "options": "Supplier"
+   "options": "Mastercard Supplier"
   },
   {
    "fieldname": "toggle_tan_authentication_section",
@@ -100,7 +100,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-11-13 10:09:23.817952",
+ "modified": "2026-02-04 15:27:13.970063",
  "modified_by": "Administrator",
  "module": "Kefiya",
  "name": "Kefiya Settings",
@@ -117,6 +117,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []

--- a/kefiya/kefiya/doctype/mastercard_supplier/mastercard_supplier.json
+++ b/kefiya/kefiya/doctype/mastercard_supplier/mastercard_supplier.json
@@ -1,0 +1,33 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2026-02-04 15:26:43.047131",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "supplier"
+ ],
+ "fields": [
+  {
+   "fieldname": "supplier",
+   "fieldtype": "Link",
+   "label": "Supplier",
+   "options": "Supplier"
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2026-02-04 15:27:01.846752",
+ "modified_by": "Administrator",
+ "module": "Kefiya",
+ "name": "Mastercard Supplier",
+ "owner": "Administrator",
+ "permissions": [],
+ "row_format": "Dynamic",
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/kefiya/kefiya/doctype/mastercard_supplier/mastercard_supplier.py
+++ b/kefiya/kefiya/doctype/mastercard_supplier/mastercard_supplier.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2026, Phamos GmbH and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class MastercardSupplier(Document):
+	pass

--- a/kefiya/kefiya/page/bank_transaction_wiz/bank_transaction_wiz.js
+++ b/kefiya/kefiya/page/bank_transaction_wiz/bank_transaction_wiz.js
@@ -299,10 +299,15 @@ kefiya.tools.AssignWizardTool = class AssignWizardTool extends (
 				),
 			});
 		} else if(this.kefiyaSettings.assign_against === 'Mastercard'){
+
+			const mastercard_rows = this.kefiyaSettings.mastercard || [];
+			const supplier_list = Array.isArray(mastercard_rows)
+				? mastercard_rows.map((row) => (typeof row === 'string' ? row : row.supplier)).filter(Boolean)
+				: [];
 			return Object.assign({}, args, {
 				...args.filters.push(
 					["Purchase Invoice", "docstatus", "=", 1],
-					["Purchase Invoice", "supplier", "=", this.kefiyaSettings.mastercard],
+					["Purchase Invoice", "supplier", "in", supplier_list],
 					["Purchase Invoice", "outstanding_amount", "!=", 0]
 				),
 			});


### PR DESCRIPTION
- Created a "Mastercard Supplier" child table with a Supplier Link field.
- Changed the Mastercard field in Kefiya Settings from a Link field to a Table MultiSelect field and linked it to the "Mastercard Supplier" child table.
- Refactored the Bank Transaction Wizard Mastercard tab to show all Purchase Invoices and Bank Transactions that match the selected Mastercard suppliers list.