### PR TITLE
feat/161-payment-request-export

### DIFF
--- a/kefiya/events/hammer_script/payment_request_on_submit.py
+++ b/kefiya/events/hammer_script/payment_request_on_submit.py
@@ -2,109 +2,135 @@ import frappe
 from frappe.utils import flt
 from datetime import datetime
 from frappe import _
-import io
+from sepaxml import SepaTransfer
+
+
+def _build_sepa_xml(payment_request_name):
+	"""
+	Build SEPA pain.001 XML for an Outward Payment Request (credit transfer).
+	Returns (xml_string, None) on success or (None, error_message) on failure.
+	"""
+	if not SepaTransfer:
+		return None, _("SEPA XML generation is not available (install sepaxml).")
+
+	doc = frappe.get_doc("Payment Request", payment_request_name)
+	if doc.payment_request_type != "Outward":
+		return None, _("SEPA XML (pain.001) is only supported for Outward payment requests.")
+
+	company_bank = frappe.get_doc("Bank Account", doc.company_bank_account)
+	party_bank = frappe.get_doc("Bank Account", doc.bank_account)
+	invoicedoc = frappe.get_doc(doc.reference_doctype, doc.reference_name)
+	partydoc = frappe.get_doc(doc.party_type, doc.party)
+	partyname = (
+		partydoc.get("customer_name")
+		if doc.party_type == "Customer"
+		else partydoc.get("supplier_name")
+		if doc.party_type == "Supplier"
+		else partydoc.get("party_name", doc.party)
+	)
+	company_name = frappe.get_cached_value("Company", doc.company, "company_name") or doc.company
+
+	if not company_bank.iban:
+		return None, _("Company bank account {0} has no IBAN.").format(doc.company_bank_account)
+	if not party_bank.iban:
+		return None, _("Party bank account {0} has no IBAN.").format(doc.bank_account)
+
+	amount_cents = int(round(flt(invoicedoc.grand_total, 2) * 100))
+	if amount_cents <= 0:
+		return None, _("Payment amount must be greater than zero.")
+
+	execution_date = doc.transaction_date
+	if execution_date:
+		if isinstance(execution_date, str):
+			execution_date = datetime.strptime(execution_date, "%Y-%m-%d").date()
+	else:
+		execution_date = datetime.now().date()
+
+	bill_no = invoicedoc.get("bill_no") if doc.reference_doctype == "Purchase Invoice" else ""
+	zweck = "Rechnung " + (bill_no if bill_no else doc.name)
+	kategorie = (doc.mode_of_payment or "").strip()
+	description = (zweck + (", " + kategorie if kategorie else "")).strip() or doc.name
+	description = description[:140]
+
+	config = {
+		"name": (company_name or doc.company)[:70],
+		"currency": doc.currency or "EUR",
+		"IBAN": (company_bank.iban or "").replace(" ", "").upper(),
+		"batch": False,
+	}
+	if company_bank.branch_code:
+		config["BIC"] = (company_bank.branch_code or "").replace(" ", "").upper()
+
+	payment = {
+		"name": (partyname or doc.party)[:70],
+		"IBAN": (party_bank.iban or "").replace(" ", "").upper(),
+		"amount": amount_cents,
+		"description": description,
+		"execution_date": execution_date,
+		"endtoend_id": doc.name[:35],
+	}
+	if party_bank.branch_code:
+		payment["BIC"] = (party_bank.branch_code or "").replace(" ", "").upper()
+	if doc.currency:
+		payment["currency"] = doc.currency
+
+	try:
+		sepa = SepaTransfer(config, schema="pain.001.001.03", clean=False)
+		sepa.add_payment(payment)
+		xml_content = sepa.export(validate=False)
+
+		if isinstance(xml_content, bytes):
+			xml_content = xml_content.decode("utf-8")
+		return xml_content, None
+	except Exception as e:
+		return None, str(e)
+
 
 @frappe.whitelist()
 def export_request(payment_request_name):
-    
-    buffer = io.StringIO()
+	try:
+		settings = frappe.get_single("Kefiya Settings")
 
-    hdrtext =   "Kontoname;" + \
-                "Kontonummer;" + \
-                "Bankleitzahl;" + \
-                "Datum;" + \
-                "Valuta;" + \
-                "Name;" + \
-                "Iban;" + \
-                "Bic;" + \
-                "Zweck;" + \
-                "Kategorie;" + \
-                "Betrag;" + \
-                "Währung\n"
-    buffer.write(hdrtext)
+		export_action = (
+			getattr(settings, "payment_request_export_action", None)
+			or getattr(settings, "payment_request_csv_action", None)
+			or "Download SEPA XML"
+		)
+		export_action = str(export_action).strip()
 
-    def safe_format(value):
-        return f'"{value}"' if value is not None else ""
+		xml_content, error = _build_sepa_xml(payment_request_name)
+		if error:
+			return {"status": "error", "message": error}
+		if not xml_content:
+			return {"status": "error", "message": _("Failed to generate SEPA XML.")}
 
-    try:
-        doc = frappe.get_doc("Payment Request", payment_request_name)
-        partybankaccount = frappe.get_doc("Bank Account", doc.bank_account)
-        bankaccount = frappe.get_doc("Bank Account", doc.company_bank_account)
-        invoicedoc = frappe.get_doc(doc.reference_doctype, doc.reference_name)
-        partydoc = frappe.get_doc(doc.party_type, doc.party)
-        partyname = (
-            partydoc.customer_name if doc.party_type == 'Customer' 
-            else partydoc.supplier_name if doc.party_type == 'Supplier' 
-            else ''
-        )
-
-        postext = (doc.company or '')+ ';'
-        postext += (bankaccount.iban or '') + ';'
-        postext += (bankaccount.branch_code or '') + ';'
-
-        if doc.transaction_date:
-            date_obj = datetime.strptime(str(doc.transaction_date), '%Y-%m-%d')
-            formatted_date = date_obj.strftime('%d.%m.%Y')
-            date = formatted_date
-            
-            postext += (date or '') + ';'+ (date or '') + ';'
-        else:
-            postext += ';;'
-
-        postext += (partyname or '') + ';'
-        postext += (partybankaccount.iban or '') + ';'
-        postext += (partybankaccount.branch_code or '') + ';'
-
-        if doc.payment_request_type == "Outward":
-            bill_no = invoicedoc.bill_no if doc.reference_doctype == "Purchase Invoice" else ""
-            postext += "Rechnung " + (bill_no if bill_no else doc.name) + ';'
-        elif doc.payment_request_type == "Inward":
-            postext += "Lastschrift " + doc.name + ';'
-
-        postext += (doc.mode_of_payment or '') + ';'
-
-        if doc.payment_request_type == "Outward":
-            postext += str(frappe.format(invoicedoc.grand_total)).replace('.','') + ';'
-        elif doc.payment_request_type == "Inward":
-            postext += "-"
-            postext += str(frappe.format(invoicedoc.grand_total)).replace('.','') + ';'
-
-        postext += (doc.currency or '') + '\n'
-        buffer.write(postext)
-
-        settings = frappe.get_single("Kefiya Settings")
-
-        return {
-            "status": "success",
-            "csv_action": settings.payment_request_csv_action,
-            "recipient_email": settings.recipient_email,
-            "data": buffer.getvalue()
-        }
-
-    except Exception as e:
-        return {"status": "error", "message": str(e)}
+		return {
+			"status": "success",
+			"export_action": export_action,
+			"recipient_email": settings.recipient_email or "",
+			"data": xml_content,
+		}
+	except Exception as e:
+		return {"status": "error", "message": str(e)}
 
 
 @frappe.whitelist()
-def send_csv_via_email(recipient_email, csv_content):
-    try:
-        subject = _("Moneyplex CSV File")
-        message = _("Please find the attached CSV file.")
-        
-        attachments = [{
-            "fname": "moneyplex_request.csv",
-            "fcontent": csv_content,
-        }]
-        
-        frappe.sendmail(
-            recipients=[recipient_email],
-            subject=subject,
-            message=message,
-            attachments=attachments,
-            delayed=False,
-            retry=3
-        )
-
-        return {"status": "success", "message": _("Email sent successfully.")}
-    except Exception as e:
-        return {"status": "error", "message": str(e)}
+def send_sepa_xml_via_email(recipient_email, xml_content):
+	try:
+		subject = _("Moneyplex SEPA File")
+		message = _("Please find the attached SEPA XML payment file.")
+		attachments = [{
+			"fname": "payment_request_pain001.xml",
+			"fcontent": xml_content,
+		}]
+		frappe.sendmail(
+			recipients=[recipient_email],
+			subject=subject,
+			message=message,
+			attachments=attachments,
+			delayed=False,
+			retry=3,
+		)
+		return {"status": "success", "message": _("Email sent successfully.")}
+	except Exception as e:
+		return {"status": "error", "message": str(e)}

--- a/kefiya/kefiya/doctype/kefiya_settings/kefiya_settings.json
+++ b/kefiya/kefiya/doctype/kefiya_settings/kefiya_settings.json
@@ -13,7 +13,7 @@
   "delete_payment_entries_on_unreconciliation",
   "mastercard",
   "column_break_qzdrd",
-  "payment_request_csv_action",
+  "payment_request_export_action",
   "recipient_email",
   "toggle_tan_authentication_section",
   "enable_tan_authentication"
@@ -39,19 +39,19 @@
    "label": "Payment Request Export"
   },
   {
-   "fieldname": "payment_request_csv_action",
+   "fieldname": "payment_request_export_action",
    "fieldtype": "Select",
    "in_list_view": 1,
-   "label": "Payment Request CSV Action",
-   "options": "Download CSV\nSend CSV via Email",
+   "label": "Payment Request Export Action",
+   "options": "Download SEPA XML\nSend SEPA XML via Email",
    "reqd": 1
   },
   {
-   "depends_on": "eval:doc.payment_request_csv_action == 'Send CSV via Email';",
+   "depends_on": "eval:doc.payment_request_export_action == 'Send SEPA XML via Email';",
    "fieldname": "recipient_email",
    "fieldtype": "Data",
    "label": "Recipient Email",
-   "mandatory_depends_on": "eval:doc.payment_request_csv_action == 'Send CSV via Email';",
+   "mandatory_depends_on": "eval:doc.payment_request_export_action == 'Send SEPA XML via Email';",
    "options": "Email"
   },
   {

--- a/kefiya/public/js/payment_request.js
+++ b/kefiya/public/js/payment_request.js
@@ -36,25 +36,29 @@ frappe.ui.form.on('Payment Request', {
             },
             callback: function(r) {
                 if (r.message.status == "success") {
-                    if (r.message.csv_action == "Download CSV"){
-						var csvContent = r.message.data;
-						var blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
+                    var export_action = r.message.export_action;
+                    var is_download = export_action == "Download SEPA XML";
+                    var is_email = export_action == "Send SEPA XML via Email";
 
-						var link = document.createElement("a");
-						if (link.download !== undefined) {
-							var url = URL.createObjectURL(blob);
-							link.setAttribute("href", url);
-							link.setAttribute("download", "moneyplex_" + frm.doc.name + ".csv");
-							link.style.visibility = 'hidden';
-							document.body.appendChild(link);
-							link.click();
-							document.body.removeChild(link);
-						}
-					}
-					else if (r.message.csv_action == "Send CSV via Email") {
+                    if (is_download) {
+                        var content = r.message.data;
+                        var blob = new Blob([content], { type: "application/xml;charset=utf-8;" });
 
-						const recipient_email = r.message.recipient_email;
-						const csv_content = r.message.data;
+                        var link = document.createElement("a");
+                        if (link.download !== undefined) {
+                            var url = URL.createObjectURL(blob);
+                            link.setAttribute("href", url);
+                            link.setAttribute("download", "moneyplex_" + frm.doc.name + ".xml");
+                            link.style.visibility = 'hidden';
+                            document.body.appendChild(link);
+                            link.click();
+                            document.body.removeChild(link);
+                        }
+                    }
+                    else if (is_email) {
+
+                        var recipient_email = r.message.recipient_email;
+                        var file_content = r.message.data;
 
                         frappe.msgprint({
                             title: __('Sending Email'),
@@ -62,35 +66,35 @@ frappe.ui.form.on('Payment Request', {
                             message: __('Email is being sent to {0}. Please wait...', [recipient_email])
                         });
 
-						frappe.call({
-							method: "kefiya.events.hammer_script.payment_request_on_submit.send_csv_via_email",
-							args: {
-								recipient_email,
-								csv_content
-							},
-							callback: function (r) {
-								
-								if (r.message) {
-									if (r.message.status === "success") {
-										frappe.show_alert({
+                        frappe.call({
+                            method: "kefiya.events.hammer_script.payment_request_on_submit.send_sepa_xml_via_email",
+                            args: {
+                                recipient_email: recipient_email,
+                                xml_content: file_content
+                            },
+                            callback: function (r) {
+
+                                if (r.message) {
+                                    if (r.message.status === "success") {
+                                        frappe.show_alert({
                                             message: __('Email sent successfully to {0}', [recipient_email]),
                                             indicator: 'green'
                                         });
-									} else {
-										frappe.msgprint({
-											title: __('Error'),
-											indicator: 'red',
-											message: r.message.message
-										});
-										frappe.validated = false;
-									}
-								}
-							}
-						})
-					}
+                                    } else {
+                                        frappe.msgprint({
+                                            title: __('Error'),
+                                            indicator: 'red',
+                                            message: r.message.message
+                                        });
+                                        frappe.validated = false;
+                                    }
+                                }
+                            }
+                        });
+                    }
                 } else {
-					frappe.msgprint(__('Error during CSV export: {0}', [r.message.message]));
-					frappe.validated = false;
+                    frappe.msgprint(__('Error during export: {0}', [r.message.message]));
+                    frappe.validated = false;
                 }
             }
         });

--- a/kefiya/public/js/purchase_invoice.js
+++ b/kefiya/public/js/purchase_invoice.js
@@ -1,6 +1,6 @@
 frappe.ui.form.on('Purchase Invoice', {
     refresh: function(frm) {
-        if (frm.is_new()) {
+        if (frm.is_new() && frm.fields_dict.originalbeleg_hochladen) {
             frm.set_value('originalbeleg_hochladen', null);
         }
     }


### PR DESCRIPTION
This pull request migrates the Payment Request export functionality from CSV to SEPA XML (pain.001 format), updating both backend and frontend logic as well as the associated configuration and user interface. The export process now generates SEPA XML files for outward payment requests, and users can choose to download the XML or send it via email. Associated settings and field names have been updated to reflect this new export method.

**Payment Request Export: SEPA XML Migration**

_Backend logic and export format:_
* Replaced CSV export with SEPA XML (pain.001) generation for outward payment requests in `payment_request_on_submit.py`, including robust validation, error handling, and the use of the `sepaxml` library for XML creation. The export and email-sending functions and their parameters have been updated accordingly.

_Configuration and settings:_
* Renamed the settings field from `payment_request_csv_action` to `payment_request_export_action` and updated the available options and dependencies to refer to SEPA XML instead of CSV in `kefiya_settings.json`. [[1]](diffhunk://#diff-3c0570937c7cdda6b24a7159f17e2785e8269b5a1c14ef0305ce4d2823a56ba9L16-R16) [[2]](diffhunk://#diff-3c0570937c7cdda6b24a7159f17e2785e8269b5a1c14ef0305ce4d2823a56ba9L42-R54)

_Frontend and user interface:_
* Updated the Payment Request client-side logic in `payment_request.js` to handle SEPA XML export and email actions, including appropriate file types, labels, and method names. Improved error messages to reflect the new export process. [[1]](diffhunk://#diff-c0efdf5621a818282393f88746f7b374eb3e300e6dcfb706d07288f58f1dcc15L39-R61) [[2]](diffhunk://#diff-c0efdf5621a818282393f88746f7b374eb3e300e6dcfb706d07288f58f1dcc15L66-R73) [[3]](diffhunk://#diff-c0efdf5621a818282393f88746f7b374eb3e300e6dcfb706d07288f58f1dcc15L89-R96)

_Other improvements:_
* Minor fix in `purchase_invoice.js` to avoid errors when resetting the `originalbeleg_hochladen` field on new forms by checking for its existence.