### PR TITLE
feat/add-confirmation-dialog-during-reconcilation

### DIFF
--- a/kefiya/kefiya/doctype/kefiya_settings/kefiya_settings.json
+++ b/kefiya/kefiya/doctype/kefiya_settings/kefiya_settings.json
@@ -11,6 +11,7 @@
   "overlap_days",
   "column_break_gv35w",
   "delete_payment_entries_on_unreconciliation",
+  "show_reconcile_confirmation_dialog",
   "mastercard",
   "column_break_qzdrd",
   "payment_request_export_action",
@@ -77,6 +78,13 @@
    "fieldname": "delete_payment_entries_on_unreconciliation",
    "fieldtype": "Check",
    "label": "Delete Payment Entries on Unreconciliation"
+  },
+  {
+   "default": "0",
+   "description": "When enabled, shows a confirmation dialog before reconciling a payment to an invoice in the Bank Transaction Wizard.",
+   "fieldname": "show_reconcile_confirmation_dialog",
+   "fieldtype": "Check",
+   "label": "Show Reconcile Confirmation Dialog"
   },
   {
    "description": "Supplier associated with the Mastercard transactions",

--- a/kefiya/kefiya/page/bank_transaction_wiz/bank_transaction_wiz.js
+++ b/kefiya/kefiya/page/bank_transaction_wiz/bank_transaction_wiz.js
@@ -491,13 +491,15 @@ kefiya.tools.AssignWizardRow = class AssignWizardRow {
 			this.bind_events();
 		} else {
 			this.data = data;
+			this.data.outstanding_amount_raw = parseFloat(this.data.outstanding_amount) || 0;
 			// formatting date based on system defaults
-			this.data.outstanding_amount = format_currency(this.data.outstanding_amount, this.data.currency); 
+			this.data.outstanding_amount = format_currency(this.data.outstanding_amount, this.data.currency);
 			this.data.posting_date = moment(this.data.posting_date).format(date_format);
-	
+
 			this.data.payments = payments;
-	
+
 			this.data.payments.forEach(payment => {
+				payment.unallocated_amount_raw = parseFloat(payment.unallocated_amount) || 0;
 				payment.date = moment(payment.date).format(date_format);
 				payment.unallocated_amount = format_currency(payment.unallocated_amount, this.data.currency);
 			});
@@ -542,8 +544,9 @@ kefiya.tools.AssignWizardRow = class AssignWizardRow {
 			const match_against = me.data.matchAgainst;
 			const bank_transaction_name = $(this).attr("data-name");
 
-			frappe.call({
-				method: "kefiya.utils.client.create_payment_entry",
+			const do_reconcile = () => {
+				frappe.call({
+					method: "kefiya.utils.client.create_payment_entry",
 				args: {
 					bank_transaction_name: bank_transaction_name,
 					invoice_name: invoice_name,
@@ -627,7 +630,40 @@ kefiya.tools.AssignWizardRow = class AssignWizardRow {
 					}
 				},
 			});
+			};
 
+			const show_dialog = kefiya.tools.assignWizardList?.kefiyaSettings?.show_reconcile_confirmation_dialog;
+			if (show_dialog) {
+				const payment = me.data.payments.find(p => p.name === bank_transaction_name);
+				const invoice_outstanding = me.data.outstanding_amount_raw ?? 0;
+				const transaction_amount = payment ? (payment.unallocated_amount_raw ?? 0) : 0;
+
+				let message;
+				if (invoice_outstanding > transaction_amount) {
+					const remaining_outstanding = invoice_outstanding - transaction_amount;
+					message = __(
+						"The invoice outstanding ({0}) is greater than the transaction amount ({1}). The full transaction amount will be applied to this invoice. The invoice will still have an outstanding amount of {2}. Are you sure you want to continue?",
+						[format_currency(invoice_outstanding, currency), format_currency(transaction_amount, currency), format_currency(remaining_outstanding, currency)]
+					);
+				} else if (invoice_outstanding < transaction_amount) {
+					const remaining_unallocated = transaction_amount - invoice_outstanding;
+					message = __(
+						"The transaction amount ({0}) is greater than the invoice outstanding ({1}). This invoice will be fully paid. The transaction will still have an unallocated amount of {2} and can be assigned to other invoices. Are you sure you want to continue?",
+						[format_currency(transaction_amount, currency), format_currency(invoice_outstanding, currency), format_currency(remaining_unallocated, currency)]
+					);
+				} else {
+					message = __(
+						"The amounts match ({0}). This invoice will be fully paid and the transaction will be fully reconciled. Are you sure you want to continue?",
+						[format_currency(invoice_outstanding, currency)]
+					);
+				}
+
+				frappe.confirm(message, () => {
+					do_reconcile();
+				});
+			} else {
+				do_reconcile();
+			}
 		});
 
 		// create journal entry from bank transaction


### PR DESCRIPTION
**Description**

* This PR introduces a confirmation dialog before reconciling a payment to an invoice in the Bank Transaction Wizard.

**Key changes:**

* Added `Show Reconcile Confirmation Dialog` checkbox on Kefiya Settings.
* If checked, It will show a detailed confirmation message when clicking on Reconcile button on bank transaction wizard page.

**Related issue(s)/ticket(s):**

* [GitLab Parent Issue](https://git.phamos.eu/phamos/kefiya/-/issues/16)

**Testing done:**

* Manual testing conducted for all implemented changes.

**Checklist:**

* [x] I followed this [[guideline](https://doku.phamos.eu/books/developer-onboarding/page/pull-request-creation)](https://doku.phamos.eu/books/developer-onboarding/page/pull-request-creation)
* [x] I created feature branch from develop
* [x] The name of the feature branch follows conventions
* [x] I created logical commit with clear messages
* [x] I pulled the changes from develop (again) and resolved possible conflicts
* [x] I pushed changes to remote feature branch
* [x] I created a Pull Request with title and description as described in the guideline
* [x] I checked if there is any conflict after creating the PR