### PR TITLE
feat/24-import-loading-speed

### DIFF
--- a/kefiya/public/js/controllers/fints_interactive.js
+++ b/kefiya/public/js/controllers/fints_interactive.js
@@ -5,6 +5,7 @@ frappe.provide("kefiya.interactive");
 
 kefiya.interactive = {
 	updateQueue: Promise.resolve(),
+	progressState: {},
 
 	enqueueUpdate: function(fn, delay) {
 		this.updateQueue = this.updateQueue
@@ -13,17 +14,43 @@ kefiya.interactive = {
 				return Promise.resolve(fn());
 			})
 			.then(() => {
-				// delay the next update
-				return new Promise((resolve) => setTimeout(resolve, delay || 500));
+				if (!delay) {
+					return;
+				}
+
+				// delay the next update only when explicitly requested
+				return new Promise((resolve) => setTimeout(resolve, delay));
 			});
 
 		return this.updateQueue;
 	},
 
 	progressbar: function(frm) {
+		this.progressState[frm.doc.name] = {
+			progress: 0,
+			completed: false,
+		};
+
 		frappe.realtime.off("fints_progressbar");
 		frappe.realtime.on("fints_progressbar", function(data) {
 			if(data.docname === frm.doc.name) {
+				const state = kefiya.interactive.progressState[frm.doc.name] || {
+					progress: 0,
+					completed: false,
+				};
+
+				if (state.completed && data.progress < 100) {
+					return;
+				}
+
+				if (data.progress < state.progress) {
+					return;
+				}
+
+				state.progress = data.progress;
+				state.completed = data.progress >= 100;
+				kefiya.interactive.progressState[frm.doc.name] = state;
+
 				kefiya.interactive.enqueueUpdate(() => {
 					if(data.reload && data.reload === true) {
 						frm.reload_doc();
@@ -40,7 +67,7 @@ kefiya.interactive = {
 							frm.reload_doc()
 						}, 500);
 					}
-				});
+				}, 0);
 			}
 		});
 

--- a/kefiya/utils/fints_controller_legacy.py
+++ b/kefiya/utils/fints_controller_legacy.py
@@ -319,5 +319,5 @@ class FinTSInteractive:
                     "progress": progress,
                     "docname": self.docname,
                     "message": message,
-                    "reload": False
+                    "reload": reload
                 }, user=frappe.session.user)


### PR DESCRIPTION
- Fixed the issue where the progress dialog continued to show “in progress” even after bank transactions were successfully imported.
- Resolved the delay in updating the progress state so the UI now accurately reflects completion status.
- Verified that the progress bar and dialog close/update correctly after import finishes.