### PR TITLE
fix/169-journal-entry-multi-company-support

### DIFF
--- a/kefiya/kefiya/page/bank_transaction_wiz/bank_transaction_wiz.js
+++ b/kefiya/kefiya/page/bank_transaction_wiz/bank_transaction_wiz.js
@@ -732,9 +732,7 @@ kefiya.tools.AssignWizardRow = class AssignWizardRow {
 						return {
 							filters: {
 								is_group: 0,
-								company: frappe.defaults.get_default("company"),
-								// account_type: partyType === 'Supplier' ? 'Expense Account' : 'Income Account',
-
+								company: me.data.company,
 							},
 						};
 					},
@@ -749,7 +747,7 @@ kefiya.tools.AssignWizardRow = class AssignWizardRow {
 						return {
 							filters: {
 								is_group: 0,
-								company: frappe.defaults.get_default("company"),
+								company: me.data.company,
 								account_type: partyType === 'Supplier' ? 'Payable' : 'Receivable',
 
 							},


### PR DESCRIPTION
- Resolved the issue with default company filtering in the Bank Transaction Journal Entry dialog by ensuring that expense and party accounts are linked to the Bank Transaction’s company instead of the system’s default company.