### PR TITLE
fix/120-duplicate-attachment-invoice

### DIFF
--- a/kefiya/public/js/purchase_invoice.js
+++ b/kefiya/public/js/purchase_invoice.js
@@ -1,7 +1,22 @@
 frappe.ui.form.on('Purchase Invoice', {
     refresh: function(frm) {
-        if (frm.is_new() && frm.fields_dict.originalbeleg_hochladen) {
-            frm.set_value('originalbeleg_hochladen', null);
+        if (frm.is_new()) {
+            // Clear all Attach and Attach Image fields dynamically
+            frm.meta.fields
+                .filter(df => ['Attach', 'Attach Image'].includes(df.fieldtype))
+                .forEach(df => {
+                    if (frm.doc[df.fieldname]) {
+                        frm.set_value(df.fieldname, null);
+                    }
+                });
+
+            // Remove any sidebar attachments
+            if (frm.attachments) {
+                let attachments = frm.attachments.get_attachments();
+                attachments.forEach(attachment => {
+                    frm.attachments.remove_attachment(attachment.name);
+                });
+            }
         }
     }
 });


### PR DESCRIPTION
- Clears all Attach and Attach Image field values dynamically when a new Purchase Invoice is created.
- Removes any carried-over attachments from the sidebar.