### PR TITLE
feat: incremental FinTS fetch starts at last imported transaction date

### DIFF
--- a/kefiya/utils/fints_controller.py
+++ b/kefiya/utils/fints_controller.py
@@ -19,7 +19,10 @@ from frappe.utils.file_manager import (
     get_file,
     get_content_hash,
 )
-from .import_bank_transaction import ImportBankTransaction
+from .import_bank_transaction import (
+    ImportBankTransaction,
+    resolve_incremental_from_date,
+)
 from .assign_payment_controller import AssignmentController
 
 class InitFailedException(Exception):
@@ -394,6 +397,16 @@ class FinTSController:
             )
             curr_doc = frappe.get_doc("Kefiya Import", kefiya_import)
             new_bank_transactions = None
+
+            # Incremental fetch: when no start date was entered, begin at the
+            # date of the most recently imported transaction for this account
+            # (clamped to the FinTS 90-day window) and fetch up to today.
+            if not curr_doc.from_date:
+                curr_doc.from_date = resolve_incremental_from_date(
+                    self.kefiya_login.bank_account
+                )
+                curr_doc.to_date = now_datetime().date()
+
             tansactions = self.get_fints_transactions(
                 curr_doc.from_date,
                 curr_doc.to_date

--- a/kefiya/utils/fints_controller_legacy.py
+++ b/kefiya/utils/fints_controller_legacy.py
@@ -18,7 +18,10 @@ from frappe.utils.file_manager import (
     get_file,
     get_content_hash,
 )
-from .import_bank_transaction import ImportBankTransaction
+from .import_bank_transaction import (
+    ImportBankTransaction,
+    resolve_incremental_from_date,
+)
 from .assign_payment_controller import AssignmentController
 
 
@@ -211,6 +214,16 @@ class FinTSController:
             )
             curr_doc = frappe.get_doc("Kefiya Import", kefiya_import)
             new_bank_transactions = None
+
+            # Incremental fetch: when no start date was entered, begin at the
+            # date of the most recently imported transaction for this account
+            # (clamped to the FinTS 90-day window) and fetch up to today.
+            if not curr_doc.from_date:
+                curr_doc.from_date = resolve_incremental_from_date(
+                    self.kefiya_login.bank_account
+                )
+                curr_doc.to_date = now_datetime().date()
+
             tansactions = self.get_fints_transactions(
                 curr_doc.from_date,
                 curr_doc.to_date

--- a/kefiya/utils/import_bank_transaction.py
+++ b/kefiya/utils/import_bank_transaction.py
@@ -4,6 +4,46 @@ from __future__ import unicode_literals
 import hashlib
 import frappe
 from frappe import _
+from frappe.utils import now_datetime, getdate, add_days
+
+# FinTS rejects a start date that is 90 days or more in the past, so the widest
+# window we may request starts at today - 89 days.
+FINTS_MAX_LOOKBACK_DAYS = 89
+
+
+def resolve_incremental_from_date(bank_account):
+    """Start date for an incremental FinTS fetch.
+
+    Returns the date of the most recently imported Bank Transaction for the
+    given bank account (so the next fetch continues where the last one ended),
+    clamped to the FinTS 90-day window. When there is no history yet, falls
+    back to the widest allowed window (today - 89 days).
+
+    :param bank_account: Bank Account name (kefiya_login.bank_account)
+    :return: datetime.date
+    """
+    today = now_datetime().date()
+    earliest = getdate(add_days(today, -FINTS_MAX_LOOKBACK_DAYS))
+
+    last_date = None
+    if bank_account:
+        rows = frappe.db.get_all(
+            "Bank Transaction",
+            # only submitted transactions; cancelled/draft rows must not
+            # determine where the next fetch starts.
+            filters={"bank_account": bank_account, "docstatus": 1},
+            fields=["date"],
+            order_by="date desc",
+            limit=1,
+        )
+        if rows and rows[0].date:
+            # never start in the future: value-dated / pre-booked entries can
+            # carry a date ahead of today; cap at today so from_date <= to_date.
+            last_date = min(getdate(rows[0].date), today)
+
+    if last_date and last_date > earliest:
+        return last_date
+    return earliest
 
 class ImportBankTransaction:
     def __init__(self, kefiya_login, interactive, allow_error=False):


### PR DESCRIPTION
## Summary
When a Kefiya Import has no `from_date`, the FinTS fetch window is now derived automatically:

- **Start** = the date of the most recently imported (submitted) Bank Transaction for the account, so each fetch continues where the last one ended.
- **End** = today.
- **Fallback** (no history yet) = today − 89 days (the widest window FinTS allows, since it rejects start dates 90+ days in the past).

A manually entered `from_date` is always respected — the automation only kicks in when it is empty.

## Details
- New helper `resolve_incremental_from_date(bank_account)` in `kefiya/utils/import_bank_transaction.py`.
- Only **submitted** Bank Transactions (`docstatus = 1`) determine the start, so cancelled/draft rows cannot create a gap.
- Future value-dated entries are capped at today, so `from_date` never exceeds `to_date`.
- Wired into both import paths: `fints_controller.py` (TAN) and `fints_controller_legacy.py` (non-TAN).

## Notes
- The start date is inclusive, so the last day is re-fetched; the existing dedup hash prevents duplicates while avoiding gaps.
- Syntax-checked and the clamp logic was verified for the no-history, recent, >90-day, and future-dated cases. Runtime verification requires a live FinTS login; no real account data is included.