### PR TITLE
fix: compose Bank Transaction override with ALYF banking (get_rounded AttributeError)

### DIFF
--- a/kefiya/overrides/bank_transaction/bank_transaction.py
+++ b/kefiya/overrides/bank_transaction/bank_transaction.py
@@ -1,7 +1,22 @@
 import frappe
-from erpnext.accounts.doctype.bank_transaction.bank_transaction import BankTransaction
 
-class CustomBankTransaction(BankTransaction):
+# When the ALYF `banking` app is installed, both apps override "Bank Transaction" via
+# `override_doctype_class`. Kefiya's class wins as the controller, but banking still
+# registers a `before_submit` doc-event that calls `doc.get_rounded(...)` -- a method
+# defined on banking's BankTransaction subclass. If Kefiya extends the plain ERPNext
+# BankTransaction instead, that method is missing and every bank-transaction import
+# fails with `AttributeError: ... has no attribute 'get_rounded'`. Extending banking's
+# class when present makes the two overrides compose; we fall back to the ERPNext base
+# when `banking` is not installed (banking is not a Kefiya dependency).
+try:
+    from banking.overrides.bank_transaction import CustomBankTransaction as BankTransactionBase
+except Exception:
+    from erpnext.accounts.doctype.bank_transaction.bank_transaction import (
+        BankTransaction as BankTransactionBase,
+    )
+
+
+class CustomBankTransaction(BankTransactionBase):
     @frappe.whitelist()
     def remove_payment_entries(self):
         payment_entries = []


### PR DESCRIPTION
When the `banking` app (ALYF) is installed alongside Kefiya, both apps override the **Bank Transaction** controller via `override_doctype_class`. Kefiya's class wins as the resolved controller, but banking still registers a `before_submit` doc-event that calls `doc.get_rounded("deposit")` — a method defined **only** on banking's `BankTransaction` subclass.

Because Kefiya extended the plain ERPNext `BankTransaction`, that method is missing on the resolved controller, so **every** bank-transaction import fails:

```
AttributeError: 'CustomBankTransaction' object has no attribute 'get_rounded'
  at banking/overrides/bank_transaction.py before_submit -> has_zero_transaction_amount_with_included_fee
```

On a production site running Kefiya + banking this silently stopped **all** statement imports (no new transactions for days; hundreds of "Error importing bank transaction" logs, 100% the same cause).

## Fix
Extend banking's `CustomBankTransaction` when it is importable, so the two overrides compose (Kefiya's methods on top of banking's, incl. `get_rounded`). Fall back to the ERPNext base when `banking` is not installed — banking is **not** a Kefiya dependency, so behaviour is unchanged for Kefiya-only installs.

Minimal change, no new dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)